### PR TITLE
Introduce support for token types (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Improvements
 * Added `entity_id`, `token_policies`, `token_type` and `orphan` flags to auth response
+* Added `entity_id`, `expire_time`, `explicit_max_ttl`, `issue_time`, `renewable` and `type` flags to token data
 * Minor dependency updates
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 * Correctly parse Map field for token metadata (#34)
 * Correctly map token policies on lookup (#35)
 
+### Features
+* Support for token types (#26)
+
 ### Improvements
+* Added `entity_id`, `token_policies`, `token_type` and `orphan` flags to auth response
 * Minor dependency updates
 
 

--- a/src/main/java/de/stklcode/jvault/connector/model/Token.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/Token.java
@@ -45,6 +45,10 @@ public final class Token {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String id;
 
+    @JsonProperty("type")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String type;
+
     @JsonProperty("display_name")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String displayName;
@@ -78,6 +82,33 @@ public final class Token {
     private Boolean renewable;
 
     /**
+     * Construct complete {@link Token} object with default type.
+     *
+     * @param id              Token ID (optional)
+     * @param displayName     Token display name (optional)
+     * @param noParent        Token has no parent (optional)
+     * @param noDefaultPolicy Do not add default policy (optional)
+     * @param ttl             Token TTL in seconds (optional)
+     * @param numUses         Number of uses (optional)
+     * @param policies        List of policies (optional)
+     * @param meta            Metadata (optional)
+     * @param renewable       Is the token renewable (optional)
+     * @deprecated As of 0.9, use {@link #Token(String, String, String, Boolean, Boolean, Integer, Integer, List, Map, Boolean)} instead.
+     */
+    @Deprecated
+    public Token(final String id,
+                 final String displayName,
+                 final Boolean noParent,
+                 final Boolean noDefaultPolicy,
+                 final Integer ttl,
+                 final Integer numUses,
+                 final List<String> policies,
+                 final Map<String, String> meta,
+                 final Boolean renewable) {
+        this(id, Type.DEFAULT.value(), displayName, noParent, noDefaultPolicy, ttl, numUses, policies, meta, renewable);
+    }
+
+    /**
      * Construct complete {@link Token} object.
      *
      * @param id              Token ID (optional)
@@ -91,6 +122,7 @@ public final class Token {
      * @param renewable       Is the token renewable (optional)
      */
     public Token(final String id,
+                 final String type,
                  final String displayName,
                  final Boolean noParent,
                  final Boolean noDefaultPolicy,
@@ -100,6 +132,7 @@ public final class Token {
                  final Map<String, String> meta,
                  final Boolean renewable) {
         this.id = id;
+        this.type = type;
         this.displayName = displayName;
         this.ttl = ttl;
         this.numUses = numUses;
@@ -115,6 +148,14 @@ public final class Token {
      */
     public String getId() {
         return id;
+    }
+
+    /**
+     * @return Token type
+     * @since 0.9
+     */
+    public String getType() {
+        return type;
     }
 
     /**
@@ -171,5 +212,26 @@ public final class Token {
      */
     public Boolean isRenewable() {
         return renewable;
+    }
+
+    /**
+     * Constants for token types.
+     */
+    public enum Type {
+        DEFAULT("default"),
+        BATCH("batch"),
+        SERVICE("service"),
+        DEFAULT_SERVICE("default-service"),
+        DEFAULT_BATCH("default-batch");
+
+        private final String value;
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/TokenBuilder.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/TokenBuilder.java
@@ -26,6 +26,7 @@ import java.util.*;
  */
 public final class TokenBuilder {
     private String id;
+    private Token.Type type;
     private String displayName;
     private Boolean noParent;
     private Boolean noDefaultPolicy;
@@ -43,6 +44,18 @@ public final class TokenBuilder {
      */
     public TokenBuilder withId(final String id) {
         this.id = id;
+        return this;
+    }
+
+    /**
+     * Specify token type.
+     *
+     * @param type the type
+     * @return self
+     * @since 0.9
+     */
+    public TokenBuilder withType(final Token.Type type) {
+        this.type = type;
         return this;
     }
 
@@ -247,6 +260,7 @@ public final class TokenBuilder {
      */
     public Token build() {
         return new Token(id,
+                type != null ? type.value() : null,
                 displayName,
                 noParent,
                 noDefaultPolicy,

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
@@ -39,6 +39,9 @@ public final class AuthData {
     @JsonProperty("policies")
     private List<String> policies;
 
+    @JsonProperty("token_policies")
+    private List<String> tokenPolicies;
+
     @JsonProperty("metadata")
     private Map<String, Object> metadata;
 
@@ -48,6 +51,15 @@ public final class AuthData {
     @JsonProperty("renewable")
     private boolean renewable;
 
+    @JsonProperty("entity_id")
+    private String entityId;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("orphan")
+    private boolean orphan;
+
     /**
      * @return Client token
      */
@@ -56,10 +68,11 @@ public final class AuthData {
     }
 
     /**
-     * @return Token accessor
+     * @return Token type
+     * @since 0.9
      */
-    public String getAccessor() {
-        return accessor;
+    public String getTokenType() {
+        return tokenType;
     }
 
     /**
@@ -67,6 +80,14 @@ public final class AuthData {
      */
     public List<String> getPolicies() {
         return policies;
+    }
+
+    /**
+     * @return List of policies associated with the ooken
+     * @since 0.9
+     */
+    public List<String> getTokenPolicies() {
+        return tokenPolicies;
     }
 
     /**
@@ -88,5 +109,28 @@ public final class AuthData {
      */
     public boolean isRenewable() {
         return renewable;
+    }
+
+    /**
+     * @return Entity ID
+     * @since 0.9
+     */
+    public String getEntityId() {
+        return entityId;
+    }
+
+    /**
+     * @return Token accessor
+     */
+    public String getAccessor() {
+        return accessor;
+    }
+
+    /**
+     * @return Token is orphan
+     * @since 0.9
+     */
+    public boolean isOrphan() {
+        return orphan;
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
@@ -45,6 +45,9 @@ public final class TokenData {
     @JsonProperty("id")
     private String id;
 
+    @JsonProperty("type")
+    private String type;
+
     @JsonProperty("meta")
     private Map<String, Object> meta;
 
@@ -96,6 +99,14 @@ public final class TokenData {
      */
     public String getId() {
         return id;
+    }
+
+    /**
+     * @return Token type
+     * @since 0.9
+     */
+    public String getType() {
+        return type;
     }
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
@@ -19,6 +19,7 @@ package de.stklcode.jvault.connector.model.response.embedded;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -42,11 +43,20 @@ public final class TokenData {
     @JsonProperty("display_name")
     private String name;
 
+    @JsonProperty("entity_id")
+    private String entityId;
+
+    @JsonProperty("expire_time")
+    private String expireTime;
+
+    @JsonProperty("explicit_max_ttl")
+    private Integer explicitMaxTtl;
+
     @JsonProperty("id")
     private String id;
 
-    @JsonProperty("type")
-    private String type;
+    @JsonProperty("issue_time")
+    private String issueTime;
 
     @JsonProperty("meta")
     private Map<String, Object> meta;
@@ -63,8 +73,14 @@ public final class TokenData {
     @JsonProperty("policies")
     private List<String> policies;
 
+    @JsonProperty("renewable")
+    private boolean renewable;
+
     @JsonProperty("ttl")
     private Integer ttl;
+
+    @JsonProperty("type")
+    private String type;
 
     /**
      * @return Token accessor
@@ -95,10 +111,66 @@ public final class TokenData {
     }
 
     /**
+     * @return Entity ID
+     * @since 0.9
+     */
+    public String getEntityId() {
+        return entityId;
+    }
+
+    /**
+     * @return Expire time as raw string value
+     * @since 0.9
+     */
+    public String getExpireTimeString() {
+        return expireTime;
+    }
+
+    /**
+     * @return Expire time (parsed)
+     * @since 0.9
+     */
+    public ZonedDateTime getExpireTime() {
+        if (expireTime == null) {
+            return null;
+        } else {
+            return ZonedDateTime.parse(expireTime);
+        }
+    }
+
+    /**
+     * @return Explicit maximum TTL
+     * @since 0.9
+     */
+    public Integer getExplicitMaxTtl() {
+        return explicitMaxTtl;
+    }
+
+    /**
      * @return Token ID
      */
     public String getId() {
         return id;
+    }
+
+    /**
+     * @return Issue time as raw string value
+     * @since 0.9
+     */
+    public String getIssueTimeString() {
+        return issueTime;
+    }
+
+    /**
+     * @return Expire time (parsed)
+     * @since 0.9
+     */
+    public ZonedDateTime getIssueTime() {
+        if (issueTime == null) {
+            return null;
+        } else {
+            return ZonedDateTime.parse(issueTime);
+        }
     }
 
     /**
@@ -136,6 +208,14 @@ public final class TokenData {
      */
     public List<String> getPolicies() {
         return policies;
+    }
+
+    /**
+     * @return Token is renewable
+     * @since 0.9
+     */
+    public boolean isRenewable() {
+        return renewable;
     }
 
     /**

--- a/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorTest.java
@@ -1039,6 +1039,7 @@ public class HTTPVaultConnectorTest {
             /* Create token */
             Token token = Token.builder()
                     .withId("test-id")
+                    .withType(Token.Type.SERVICE)
                     .withDisplayName("test name")
                     .build();
 
@@ -1116,6 +1117,7 @@ public class HTTPVaultConnectorTest {
             /* Create token with attributes */
             Token token = Token.builder()
                     .withId("my-token")
+                    .withType(Token.Type.SERVICE)
                     .build();
             try {
                 connector.createToken(token);
@@ -1131,6 +1133,7 @@ public class HTTPVaultConnectorTest {
                 assertThat("Unexpected token ID", res.getData().getId(), is(token.getId()));
                 assertThat("Unexpected number of policies", res.getData().getPolicies(), hasSize(1));
                 assertThat("Unexpected policy", res.getData().getPolicies(), contains("root"));
+                assertThat("Unexpected token type", res.getData().getType(), is(token.getType()));
             } catch (VaultConnectorException e) {
                 fail("Token creation failed.");
             }

--- a/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorTest.java
@@ -1158,6 +1158,7 @@ public class HTTPVaultConnectorTest {
                 assertThat("Unexpected number of policies", res.getData().getPolicies(), hasSize(1));
                 assertThat("Unexpected policy", res.getData().getPolicies(), contains("root"));
                 assertThat("Unexpected token type", res.getData().getType(), is(token.getType()));
+                assertThat("Issue time expected to be filled", res.getData().getIssueTime(), is(notNullValue()));
             } catch (VaultConnectorException e) {
                 fail("Token creation failed.");
             }

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenBuilderTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenBuilderTest.java
@@ -53,7 +53,7 @@ public class TokenBuilderTest {
     private static final String META_KEY_2 = "key2";
     private static final String META_VALUE_2 = "value2";
     private static final Boolean RENEWABLE = true;
-    private static final String JSON_FULL = "{\"id\":\"test-id\",\"display_name\":\"display-name\",\"no_parent\":false,\"no_default_policy\":false,\"ttl\":123,\"num_uses\":4,\"policies\":[\"policy\"],\"meta\":{\"key\":\"value\"},\"renewable\":true}";
+    private static final String JSON_FULL = "{\"id\":\"test-id\",\"type\":\"service\",\"display_name\":\"display-name\",\"no_parent\":false,\"no_default_policy\":false,\"ttl\":123,\"num_uses\":4,\"policies\":[\"policy\"],\"meta\":{\"key\":\"value\"},\"renewable\":true}";
 
     @BeforeAll
     public static void init() {
@@ -68,6 +68,7 @@ public class TokenBuilderTest {
     public void buildDefaultTest() throws JsonProcessingException {
         Token token = new TokenBuilder().build();
         assertThat(token.getId(), is(nullValue()));
+        assertThat(token.getType(), is(nullValue()));
         assertThat(token.getDisplayName(), is(nullValue()));
         assertThat(token.getNoParent(), is(nullValue()));
         assertThat(token.getNoDefaultPolicy(), is(nullValue()));
@@ -88,6 +89,7 @@ public class TokenBuilderTest {
     public void buildFullTest() throws JsonProcessingException {
         Token token = new TokenBuilder()
                 .withId(ID)
+                .withType(Token.Type.SERVICE)
                 .withDisplayName(DISPLAY_NAME)
                 .withNoParent(NO_PARENT)
                 .withNoDefaultPolicy(NO_DEFAULT_POLICY)
@@ -98,6 +100,7 @@ public class TokenBuilderTest {
                 .withRenewable(RENEWABLE)
                 .build();
         assertThat(token.getId(), is(ID));
+        assertThat(token.getType(), is(Token.Type.SERVICE.value()));
         assertThat(token.getDisplayName(), is(DISPLAY_NAME));
         assertThat(token.getNoParent(), is(NO_PARENT));
         assertThat(token.getNoDefaultPolicy(), is(NO_DEFAULT_POLICY));

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
@@ -44,6 +44,9 @@ public class AuthResponseTest {
     private static final String AUTH_META_VALUE = "armon";
     private static final Integer AUTH_LEASE_DURATION = 3600;
     private static final Boolean AUTH_RENEWABLE = true;
+    private static final String AUTH_ENTITY_ID = "";
+    private static final String AUTH_TOKEN_TYPE = "service";
+    private static final Boolean AUTH_ORPHAN = false;
 
     private static final String RES_JSON = "{\n" +
             "  \"auth\": {\n" +
@@ -53,11 +56,18 @@ public class AuthResponseTest {
             "      \"" + AUTH_POLICY_1 + "\", \n" +
             "      \"" + AUTH_POLICY_2 + "\"\n" +
             "    ],\n" +
+            "    \"token_policies\": [\n" +
+            "      \"" + AUTH_POLICY_2 + "\",\n" +
+            "      \"" + AUTH_POLICY_1 + "\" \n" +
+            "    ],\n" +
             "    \"metadata\": {\n" +
             "      \"" + AUTH_META_KEY + "\": \"" + AUTH_META_VALUE + "\"\n" +
             "    },\n" +
             "    \"lease_duration\": " + AUTH_LEASE_DURATION + ",\n" +
-            "    \"renewable\": " + AUTH_RENEWABLE + "\n" +
+            "    \"renewable\": " + AUTH_RENEWABLE + ",\n" +
+            "    \"entity_id\": \"" + AUTH_ENTITY_ID + "\",\n" +
+            "    \"token_type\": \"" + AUTH_TOKEN_TYPE + "\",\n" +
+            "    \"orphan\": " + AUTH_ORPHAN + "\n" +
             "  }\n" +
             "}";
 
@@ -104,8 +114,16 @@ public class AuthResponseTest {
             assertThat("Incorrect auth client token", data.getClientToken(), is(AUTH_CLIENT_TOKEN));
             assertThat("Incorrect auth lease duration", data.getLeaseDuration(), is(AUTH_LEASE_DURATION));
             assertThat("Incorrect auth renewable flag", data.isRenewable(), is(AUTH_RENEWABLE));
+            assertThat("Incorrect auth orphan flag", data.isOrphan(), is(AUTH_ORPHAN));
+            assertThat("Incorrect auth token type", data.getTokenType(), is(AUTH_TOKEN_TYPE));
+            assertThat("Incorrect auth entity id", data.getEntityId(), is(AUTH_ENTITY_ID));
             assertThat("Incorrect number of policies", data.getPolicies(), hasSize(2));
-            assertThat("Incorrect auth policies", data.getPolicies(), containsInAnyOrder(AUTH_POLICY_1, AUTH_POLICY_2));
+            assertThat("Incorrect auth policies", data.getPolicies(), containsInRelativeOrder(AUTH_POLICY_1, AUTH_POLICY_2));
+            assertThat("Incorrect number of token policies", data.getTokenPolicies(), hasSize(2));
+            assertThat("Incorrect token policies", data.getTokenPolicies(), containsInRelativeOrder(AUTH_POLICY_2, AUTH_POLICY_1));
+            assertThat("Incorrect auth metadata size", data.getMetadata().entrySet(), hasSize(1));
+            assertThat("Incorrect auth metadata", data.getMetadata().get(AUTH_META_KEY), is(AUTH_META_VALUE));
+
         } catch (IOException e) {
             fail("AuthResponse deserialization failed: " + e.getMessage());
         }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
@@ -22,6 +22,7 @@ import de.stklcode.jvault.connector.model.response.embedded.TokenData;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,26 +39,40 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TokenResponseTest {
     private static final Integer TOKEN_CREATION_TIME = 1457533232;
     private static final Integer TOKEN_TTL = 2764800;
+    private static final Integer TOKEN_EXPLICIT_MAX_TTL = 0;
     private static final String TOKEN_DISPLAY_NAME = "token";
     private static final String TOKEN_META_KEY = "foo";
     private static final String TOKEN_META_VALUE = "bar";
     private static final Integer TOKEN_NUM_USES = 0;
     private static final Boolean TOKEN_ORPHAN = false;
+    private static final Boolean TOKEN_RENEWABLE = true;
     private static final String TOKEN_PATH = "auth/token/create";
     private static final String TOKEN_POLICY_1 = "default";
     private static final String TOKEN_POLICY_2 = "web";
     private static final Boolean RES_RENEWABLE = false;
     private static final Integer RES_TTL = 2591976;
     private static final Integer RES_LEASE_DURATION = 0;
+    private static final String TOKEN_ACCESSOR = "VKvzT2fKHFsZFUus9LyoXCvu";
+    private static final String TOKEN_ENTITY_ID = "7d2e3179-f69b-450c-7179-ac8ee8bd8ca9";
+    private static final String TOKEN_EXPIRE_TIME = "2018-05-19T11:35:54.466476215-04:00";
+    private static final String TOKEN_ID = "my-token";
+    private static final String TOKEN_ISSUE_TIME = "2018-04-17T11:35:54.466476078-04:00";
+    private static final String TOKEN_TYPE = "service";
 
     private static final String RES_JSON = "{\n" +
             "  \"lease_id\": \"\",\n" +
             "  \"renewable\": " + RES_RENEWABLE + ",\n" +
             "  \"lease_duration\": " + RES_LEASE_DURATION + ",\n" +
             "  \"data\": {\n" +
+            "    \"accessor\": \"" + TOKEN_ACCESSOR + "\",\n" +
             "    \"creation_time\": " + TOKEN_CREATION_TIME + ",\n" +
             "    \"creation_ttl\": " + TOKEN_TTL + ",\n" +
             "    \"display_name\": \"" + TOKEN_DISPLAY_NAME + "\",\n" +
+            "    \"entity_id\": \"" + TOKEN_ENTITY_ID + "\",\n" +
+            "    \"expire_time\": \"" + TOKEN_EXPIRE_TIME + "\",\n" +
+            "    \"explicit_max_ttl\": \"" + TOKEN_EXPLICIT_MAX_TTL + "\",\n" +
+            "    \"id\": \"" + TOKEN_ID + "\",\n" +
+            "    \"issue_time\": \"" + TOKEN_ISSUE_TIME + "\",\n" +
             "    \"meta\": {\n" +
             "      \"" + TOKEN_META_KEY + "\": \"" + TOKEN_META_VALUE + "\"\n" +
             "    },\n" +
@@ -68,7 +83,9 @@ public class TokenResponseTest {
             "      \"" + TOKEN_POLICY_1 + "\", \n" +
             "      \"" + TOKEN_POLICY_2 + "\"\n" +
             "    ],\n" +
-            "    \"ttl\": " + RES_TTL + "\n" +
+            "    \"renewable\": " + TOKEN_RENEWABLE + ",\n" +
+            "    \"ttl\": " + RES_TTL + ",\n" +
+            "    \"type\": \"" + TOKEN_TYPE + "\"\n" +
             "  },\n" +
             "  \"warnings\": null,\n" +
             "  \"auth\": null\n" +
@@ -107,23 +124,32 @@ public class TokenResponseTest {
             TokenResponse res = new ObjectMapper().readValue(RES_JSON, TokenResponse.class);
             assertThat("Parsed response is NULL", res, is(notNullValue()));
             assertThat("Incorrect lease duration", res.getLeaseDuration(), is(RES_LEASE_DURATION));
-            assertThat("Incorrect renewable status", res.isRenewable(), is(RES_RENEWABLE));
+            assertThat("Incorrect response renewable flag", res.isRenewable(), is(RES_RENEWABLE));
+            assertThat("Incorrect response lease duration", res.getLeaseDuration(), is(RES_LEASE_DURATION));
             // Extract token data.
             TokenData data = res.getData();
             assertThat("Token data is NULL", data, is(notNullValue()));
+            assertThat("Incorrect token accessor", data.getAccessor(), is(TOKEN_ACCESSOR));
             assertThat("Incorrect token creation time", data.getCreationTime(), is(TOKEN_CREATION_TIME));
             assertThat("Incorrect token creation TTL", data.getCreationTtl(), is(TOKEN_TTL));
             assertThat("Incorrect token display name", data.getName(), is(TOKEN_DISPLAY_NAME));
+            assertThat("Incorrect token entity ID", data.getEntityId(), is(TOKEN_ENTITY_ID));
+            assertThat("Incorrect token expire time", data.getExpireTimeString(), is(TOKEN_EXPIRE_TIME));
+            assertThat("Incorrect parsed token expire time", data.getExpireTime(), is(ZonedDateTime.parse(TOKEN_EXPIRE_TIME)));
+            assertThat("Incorrect token explicit max TTL", data.getExplicitMaxTtl(), is(TOKEN_EXPLICIT_MAX_TTL));
+            assertThat("Incorrect token ID", data.getId(), is(TOKEN_ID));
+            assertThat("Incorrect token issue time", data.getIssueTimeString(), is(TOKEN_ISSUE_TIME));
+            assertThat("Incorrect parsed token issue time", data.getIssueTime(), is(ZonedDateTime.parse(TOKEN_ISSUE_TIME)));
+            assertThat("Incorrect token metadata size", data.getMeta().entrySet(), hasSize(1));
+            assertThat("Incorrect token metadata", data.getMeta().get(TOKEN_META_KEY), is(TOKEN_META_VALUE));
             assertThat("Incorrect token number of uses", data.getNumUses(), is(TOKEN_NUM_USES));
             assertThat("Incorrect token orphan flag", data.isOrphan(), is(TOKEN_ORPHAN));
             assertThat("Incorrect token path", data.getPath(), is(TOKEN_PATH));
-            assertThat("Incorrect token metadata size", data.getMeta().entrySet(), hasSize(1));
-            assertThat("Incorrect token metadata", data.getMeta().get(TOKEN_META_KEY), is(TOKEN_META_VALUE));
             assertThat("Incorrect number of token policies", data.getPolicies(), hasSize(2));
             assertThat("Incorrect token policies", data.getPolicies(), contains(TOKEN_POLICY_1, TOKEN_POLICY_2));
-            assertThat("Incorrect response renewable flag", res.isRenewable(), is(RES_RENEWABLE));
-            assertThat("Incorrect response TTL", data.getTtl(), is(RES_TTL));
-            assertThat("Incorrect response lease duration", res.getLeaseDuration(), is(RES_LEASE_DURATION));
+            assertThat("Incorrect token renewable flag", data.isRenewable(), is(TOKEN_RENEWABLE));
+            assertThat("Incorrect token TTL", data.getTtl(), is(RES_TTL));
+            assertThat("Incorrect token type", data.getType(), is(TOKEN_TYPE));
         } catch (IOException e) {
             fail("TokenResponse deserialization failed: " + e.getMessage());
         }


### PR DESCRIPTION
Closes #26.

Token types (`service` or `batch`) are now supported by the connector.

Type can be set during creation using the builder:
```java
Token.builder().withType(Token.Type.SERVICE).build();
```
and  read from responses using `TokenData#getType()` or `AuthData#getTokenType()`.

Along with those changes the mentioned model classes have been extended by various missing flags:
* `AuthData`
  * `entity_id`, `token_policies`, `token_type`, `orphan`
* `TokenData`
  * `entity_id`, `expire_time`, `explicit_max_ttl`, `issue_time`, `renewable`, `type`