### PR TITLE
add support for token roles (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Features
 * Support for token types (#26)
+* Support for token role handling (#27)
 
 ### Improvements
 * Added `entity_id`, `token_policies`, `token_type` and `orphan` flags to auth response

--- a/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
@@ -20,10 +20,7 @@ import de.stklcode.jvault.connector.exception.AuthorizationRequiredException;
 import de.stklcode.jvault.connector.exception.InvalidRequestException;
 import de.stklcode.jvault.connector.exception.VaultConnectorException;
 import de.stklcode.jvault.connector.internal.RequestHelper;
-import de.stklcode.jvault.connector.model.AppRole;
-import de.stklcode.jvault.connector.model.AppRoleSecret;
-import de.stklcode.jvault.connector.model.AuthBackend;
-import de.stklcode.jvault.connector.model.Token;
+import de.stklcode.jvault.connector.model.*;
 import de.stklcode.jvault.connector.model.response.*;
 import de.stklcode.jvault.connector.model.response.embedded.AuthMethod;
 
@@ -49,6 +46,7 @@ public class HTTPVaultConnector implements VaultConnector {
     private static final String PATH_TOKEN = "auth/token";
     private static final String PATH_LOOKUP = "/lookup";
     private static final String PATH_CREATE = "/create";
+    private static final String PATH_ROLES = "/roles";
     private static final String PATH_CREATE_ORPHAN = "/create-orphan";
     private static final String PATH_AUTH_USERPASS = "auth/userpass/login/";
     private static final String PATH_AUTH_APPID = "auth/app-id/";
@@ -530,7 +528,7 @@ public class HTTPVaultConnector implements VaultConnector {
         if (cas != null) {
             options.put("cas", cas);
         }
-        
+
         Map<String, Object> payload = new HashMap<>();
         payload.put("data", data);
         payload.put("options", options);
@@ -699,6 +697,51 @@ public class HTTPVaultConnector implements VaultConnector {
         Map<String, String> param = new HashMap<>();
         param.put("token", token);
         return request.get(PATH_TOKEN + PATH_LOOKUP, param, token, TokenResponse.class);
+    }
+
+    @Override
+    public boolean createOrUpdateTokenRole(final String name, final TokenRole role) throws VaultConnectorException {
+        requireAuth();
+
+        if (name == null) {
+            throw new InvalidRequestException("Role name must be provided.");
+        } else if (role == null) {
+            throw new InvalidRequestException("Role must be provided.");
+        }
+
+        // Issue request and expect code 204 with empty response.
+        request.postWithoutResponse(PATH_TOKEN + PATH_ROLES + "/" + name, role, token);
+
+        return true;
+    }
+
+    @Override
+    public TokenRoleResponse readTokenRole(final String name) throws VaultConnectorException {
+        requireAuth();
+
+        // Request HTTP response and parse response.
+        return request.get(PATH_TOKEN + PATH_ROLES + "/" + name, new HashMap<>(), token, TokenRoleResponse.class);
+    }
+
+    @Override
+    public List<String> listTokenRoles() throws VaultConnectorException {
+        requireAuth();
+
+        return list(PATH_TOKEN + PATH_ROLES);
+    }
+
+    @Override
+    public boolean deleteTokenRole(final String name) throws VaultConnectorException {
+        requireAuth();
+
+        if (name == null) {
+            throw new InvalidRequestException("Role name must be provided.");
+        }
+
+        // Issue request and expect code 204 with empty response.
+        request.deleteWithoutResponse(PATH_TOKEN + PATH_ROLES + "/" + name, token);
+
+        return true;
     }
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
@@ -233,7 +233,7 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * Delete AppRole role from Vault.
      *
      * @param roleName The role anme
-     * @return {@code true} on succevss
+     * @return {@code true} on success
      * @throws VaultConnectorException on error
      */
     boolean deleteAppRole(final String roleName) throws VaultConnectorException;
@@ -446,7 +446,7 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * Prefix {@code secret/} is automatically added to path.
      * Only available for KV v2 secrets.
      *
-     * @param key Secret identifier.
+     * @param key  Secret identifier.
      * @param data Secret content. Value must be be JSON serializable.
      * @return Metadata for the created/updated secret.
      * @throws VaultConnectorException on error
@@ -463,8 +463,8 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * Only available for KV v2 secrets.
      *
      * @param mount Secret store mountpoint (without leading or trailing slash).
-     * @param key Secret identifier
-     * @param data Secret content. Value must be be JSON serializable.
+     * @param key   Secret identifier
+     * @param data  Secret content. Value must be be JSON serializable.
      * @return Metadata for the created/updated secret.
      * @throws VaultConnectorException on error
      * @since 0.8
@@ -480,9 +480,9 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * Only available for KV v2 secrets.
      *
      * @param mount Secret store mountpoint (without leading or trailing slash).
-     * @param key Secret identifier
-     * @param data Secret content. Value must be be JSON serializable.
-     * @param cas  Use Check-And-Set operation, i.e. only allow writing if current version matches this value.
+     * @param key   Secret identifier
+     * @param data  Secret content. Value must be be JSON serializable.
+     * @param cas   Use Check-And-Set operation, i.e. only allow writing if current version matches this value.
      * @return Metadata for the created/updated secret.
      * @throws VaultConnectorException on error
      * @since 0.8
@@ -540,7 +540,7 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * Path {@code secret/metadata/<key>} is read here.
      * Only available for KV v2 secrets.
      *
-     * @param key Secret identifier
+     * @param key         Secret identifier
      * @param maxVersions Maximum number of versions (fallback to backend default if {@code null})
      * @param casRequired Specify if Check-And-Set is required for this secret.
      * @throws VaultConnectorException on error
@@ -737,8 +737,8 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * Prefix {@code secret/} is automatically added to path.
      * Only available for KV v2 stores.
      *
-     * @param mount    Secret store mountpoint (without leading or trailing slash).
-     * @param key Secret path.
+     * @param mount Secret store mountpoint (without leading or trailing slash).
+     * @param key   Secret path.
      * @throws VaultConnectorException on error
      * @since 0.8
      */
@@ -888,7 +888,57 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      */
     TokenResponse lookupToken(final String token) throws VaultConnectorException;
 
+    /**
+     * Create a new or update an existing token role.
+     *
+     * @param role the role entity (name must be set)
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    default boolean createOrUpdateTokenRole(final TokenRole role) throws VaultConnectorException {
+        return createOrUpdateTokenRole(role.getName(), role);
+    }
 
+    /**
+     * Create a new or update an existing token role.
+     *
+     * @param name the role name (overrides name possibly set in role entity)
+     * @param role the role entity
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    boolean createOrUpdateTokenRole(final String name, final TokenRole role) throws VaultConnectorException;
+
+    /**
+     * Lookup token information.
+     *
+     * @param name the role name
+     * @return the result response
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    TokenRoleResponse readTokenRole(final String name) throws VaultConnectorException;
+
+    /**
+     * List available token roles from Vault.
+     *
+     * @return List of token roles
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    List<String> listTokenRoles() throws VaultConnectorException;
+
+    /**
+     * Delete a token role.
+     *
+     * @param name the role name to delete
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    boolean deleteTokenRole(final String name) throws VaultConnectorException;
 
     /**
      * Read credentials for MySQL backend at default mount point.

--- a/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2016-2020 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Vault Token Role metamodel.
+ *
+ * @author Stefan Kalscheuer
+ * @since 0.9
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class TokenRole {
+    /**
+     * Get {@link TokenRoleBuilder} instance.
+     *
+     * @return Token Role Builder.
+     * @since 0.9
+     */
+    public static TokenRoleBuilder builder() {
+        return new TokenRoleBuilder();
+    }
+
+    @JsonProperty("name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String name;
+
+    @JsonProperty("allowed_policies")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<String> allowedPolicies;
+
+    @JsonProperty("disallowed_policies")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<String> disallowedPolicies;
+
+    @JsonProperty("orphan")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean orphan;
+
+    @JsonProperty("renewable")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean renewable;
+
+    @JsonProperty("path_suffix")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String pathSuffix;
+
+    @JsonProperty("allowed_entity_aliases")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<String> allowedEntityAliases;
+
+    @JsonProperty("token_bound_cidrs")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<String> tokenBoundCidrs;
+
+    @JsonProperty("token_explicit_max_ttl")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer tokenExplicitMaxTtl;
+
+    @JsonProperty("token_no_default_policy")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean tokenNoDefaultPolicy;
+
+    @JsonProperty("token_num_uses")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer tokenNumUses;
+
+    @JsonProperty("token_period")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer tokenPeriod;
+
+    @JsonProperty("token_type")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String tokenType;
+
+
+    /**
+     * Construct complete {@link TokenRole} object.
+     *
+     * @param name                 Token Role name (redundant for creation).
+     * @param allowedPolicies      Allowed policies (optional)
+     * @param disallowedPolicies   Disallowed policies (optional)
+     * @param orphan               Role is orphan? (optional)
+     * @param renewable            Role is renewable? (optional)
+     * @param pathSuffix           Paht suffix (optional)
+     * @param allowedEntityAliases Allowed entity aliases (optional)
+     * @param tokenBoundCidrs      Token bound CIDR blocks (optional)
+     * @param tokenExplicitMaxTtl  Token explicit maximum TTL (optional)
+     * @param tokenNoDefaultPolicy Token wihtout default policy? (optional)
+     * @param tokenNumUses         Token number of uses (optional)
+     * @param tokenPeriod          Token period (optional)
+     * @param tokenType            Token type (optional)
+     */
+    public TokenRole(final String name,
+                     final List<String> allowedPolicies,
+                     final List<String> disallowedPolicies,
+                     final Boolean orphan,
+                     final Boolean renewable,
+                     final String pathSuffix,
+                     final List<String> allowedEntityAliases,
+                     final List<String> tokenBoundCidrs,
+                     final Integer tokenExplicitMaxTtl,
+                     final Boolean tokenNoDefaultPolicy,
+                     final Integer tokenNumUses,
+                     final Integer tokenPeriod,
+                     final String tokenType) {
+        this.name = name;
+        this.allowedPolicies = allowedPolicies;
+        this.disallowedPolicies = disallowedPolicies;
+        this.orphan = orphan;
+        this.renewable = renewable;
+        this.pathSuffix = pathSuffix;
+        this.allowedEntityAliases = allowedEntityAliases;
+        this.tokenBoundCidrs = tokenBoundCidrs;
+        this.tokenExplicitMaxTtl = tokenExplicitMaxTtl;
+        this.tokenNoDefaultPolicy = tokenNoDefaultPolicy;
+        this.tokenNumUses = tokenNumUses;
+        this.tokenPeriod = tokenPeriod;
+        this.tokenType = tokenType;
+    }
+
+    /**
+     * @return Token Role name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return List of allowed policies
+     */
+    public List<String> getAllowedPolicies() {
+        return allowedPolicies;
+    }
+
+    /**
+     * @return List of disallowed policies
+     */
+    public List<String> getDisallowedPolicies() {
+        return disallowedPolicies;
+    }
+
+    /**
+     * @return Is Roken Role orphan?
+     */
+    public Boolean getOrphan() {
+        return orphan;
+    }
+
+    /**
+     * @return Is Roken Role renewable?
+     */
+    public Boolean getRenewable() {
+        return renewable;
+    }
+
+    /**
+     * @return Path suffix
+     */
+    public String getPathSuffix() {
+        return pathSuffix;
+    }
+
+    /**
+     * @return List of allowed entity aliases
+     */
+    public List<String> getAllowedEntityAliases() {
+        return allowedEntityAliases;
+    }
+
+    /**
+     * @return Token bound CIDR blocks
+     */
+    public List<String> getTokenBoundCidrs() {
+        return tokenBoundCidrs;
+    }
+
+    /**
+     * @return Token explicit maximum TTL
+     */
+    public Integer getTokenExplicitMaxTtl() {
+        return tokenExplicitMaxTtl;
+    }
+
+    /**
+     * @return Token without default policy?
+     */
+    public Boolean getTokenNoDefaultPolicy() {
+        return tokenNoDefaultPolicy;
+    }
+
+    /**
+     * @return Token number of uses
+     */
+    public Integer getTokenNumUses() {
+        return tokenNumUses;
+    }
+
+    /**
+     * @return Token period
+     */
+    public Integer getTokenPeriod() {
+        return tokenPeriod;
+    }
+
+    /**
+     * @return Token type
+     */
+    public String getTokenType() {
+        return tokenType;
+    }
+}

--- a/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
@@ -92,6 +92,11 @@ public final class TokenRole {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String tokenType;
 
+    /**
+     * Construct empty {@link TokenRole} object.
+     */
+    public TokenRole() {
+    }
 
     /**
      * Construct complete {@link TokenRole} object.

--- a/src/main/java/de/stklcode/jvault/connector/model/TokenRoleBuilder.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/TokenRoleBuilder.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2016-2020 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder for vault token roles.
+ *
+ * @author Stefan Kalscheuer
+ * @since 0.9
+ */
+public final class TokenRoleBuilder {
+    private List<String> allowedPolicies;
+    private List<String> disallowedPolicies;
+    private Boolean orphan;
+    private Boolean renewable;
+    private String pathSuffix;
+    private List<String> allowedEntityAliases;
+    private List<String> tokenBoundCidrs;
+    private Integer tokenExplicitMaxTtl;
+    private Boolean tokenNoDefaultPolicy;
+    private Integer tokenNumUses;
+    private Integer tokenPeriod;
+    private Token.Type tokenType;
+
+    /**
+     * Add an allowed policy.
+     *
+     * @param allowedPolicy allowed policy to add
+     * @return self
+     */
+    public TokenRoleBuilder withAllowedPolicy(final String allowedPolicy) {
+        if (allowedPolicy != null) {
+            if (this.allowedPolicies == null) {
+                this.allowedPolicies = new ArrayList<>();
+            }
+            this.allowedPolicies.add(allowedPolicy);
+        }
+        return this;
+    }
+
+    /**
+     * Add allowed policies.
+     *
+     * @param allowedPolicies list of allowed policies
+     * @return self
+     */
+    public TokenRoleBuilder withAllowedPolicies(final List<String> allowedPolicies) {
+        if (allowedPolicies != null) {
+            if (this.allowedPolicies == null) {
+                this.allowedPolicies = new ArrayList<>();
+            }
+            this.allowedPolicies.addAll(allowedPolicies);
+        }
+        return this;
+    }
+
+    /**
+     * Add a disallowed policy.
+     *
+     * @param disallowedPolicy disallowed policy to add
+     * @return self
+     */
+    public TokenRoleBuilder withDisallowedPolicy(final String disallowedPolicy) {
+        if (disallowedPolicy != null) {
+            if (this.disallowedPolicies == null) {
+                this.disallowedPolicies = new ArrayList<>();
+            }
+            this.disallowedPolicies.add(disallowedPolicy);
+        }
+        return this;
+    }
+
+    /**
+     * Add disallowed policies.
+     *
+     * @param disallowedPolicies list of disallowed policies
+     * @return self
+     */
+    public TokenRoleBuilder withDisallowedPolicies(final List<String> disallowedPolicies) {
+        if (disallowedPolicies != null) {
+            if (this.disallowedPolicies == null) {
+                this.disallowedPolicies = new ArrayList<>();
+            }
+            this.disallowedPolicies.addAll(disallowedPolicies);
+        }
+        return this;
+    }
+
+    /**
+     * Set TRUE if the token role should be created orphan.
+     *
+     * @param orphan if TRUE, token role is created as orphan
+     * @return self
+     */
+    public TokenRoleBuilder orphan(final Boolean orphan) {
+        this.orphan = orphan;
+        return this;
+    }
+
+    /**
+     * Set TRUE if the token role should be created renewable.
+     *
+     * @param renewable if TRUE, token role is created renewable
+     * @return self
+     */
+    public TokenRoleBuilder renewable(final Boolean renewable) {
+        this.renewable = renewable;
+        return this;
+    }
+
+    /**
+     * Set token role path suffix.
+     *
+     * @param pathSuffix path suffix to use
+     * @return self
+     */
+    public TokenRoleBuilder withPathSuffix(final String pathSuffix) {
+        this.pathSuffix = pathSuffix;
+        return this;
+    }
+
+    /**
+     * Add an allowed entity alias.
+     *
+     * @param allowedEntityAlias allowed entity alias to add
+     * @return self
+     */
+    public TokenRoleBuilder withAllowedEntityAlias(final String allowedEntityAlias) {
+        if (allowedEntityAlias != null) {
+            if (this.allowedEntityAliases == null) {
+                this.allowedEntityAliases = new ArrayList<>();
+            }
+            this.allowedEntityAliases.add(allowedEntityAlias);
+        }
+        return this;
+    }
+
+    /**
+     * Add allowed entity aliases.
+     *
+     * @param allowedEntityAliases list of allowed entity aliases to add
+     * @return self
+     */
+    public TokenRoleBuilder withAllowedEntityAliases(final List<String> allowedEntityAliases) {
+        if (allowedEntityAliases != null) {
+            if (this.allowedEntityAliases == null) {
+                this.allowedEntityAliases = new ArrayList<>();
+            }
+            this.allowedEntityAliases.addAll(allowedEntityAliases);
+        }
+        return this;
+    }
+
+    /**
+     * Add a single bound CIDR.
+     *
+     * @param tokenBoundCidr bound CIDR to add
+     * @return self
+     */
+    public TokenRoleBuilder withTokenBoundCidr(final String tokenBoundCidr) {
+        if (tokenBoundCidr != null) {
+            if (this.tokenBoundCidrs == null) {
+                this.tokenBoundCidrs = new ArrayList<>();
+            }
+            this.tokenBoundCidrs.add(tokenBoundCidr);
+        }
+        return this;
+    }
+
+    /**
+     * Add a list of bound CIDRs.
+     *
+     * @param tokenBoundCidrs list of bound CIDRs to add
+     * @return self
+     */
+    public TokenRoleBuilder withTokenBoundCidrs(final List<String> tokenBoundCidrs) {
+        if (tokenBoundCidrs != null) {
+            if (this.tokenBoundCidrs == null) {
+                this.tokenBoundCidrs = new ArrayList<>();
+            }
+            this.tokenBoundCidrs.addAll(tokenBoundCidrs);
+        }
+        return this;
+    }
+
+    /**
+     * Set explicit max. TTL for token.
+     *
+     * @param tokenExplicitMaxTtl explicit maximum TTL
+     * @return self
+     */
+    public TokenRoleBuilder withTokenExplicitMaxTtl(final Integer tokenExplicitMaxTtl) {
+        this.tokenExplicitMaxTtl = tokenExplicitMaxTtl;
+        return this;
+    }
+
+    /**
+     * Set TRUE if the token role should be created renewable.
+     *
+     * @param tokenNoDefaultPolicy if TRUE, token is created without default policy.
+     * @return self
+     */
+    public TokenRoleBuilder withTokenNoDefaultPolicy(final Boolean tokenNoDefaultPolicy) {
+        this.tokenNoDefaultPolicy = tokenNoDefaultPolicy;
+        return this;
+    }
+
+    /**
+     * Set number of uses for tokens.
+     *
+     * @param tokenNumUses number of uses for associated tokens.
+     * @return self
+     */
+    public TokenRoleBuilder withTokenNumUses(final Integer tokenNumUses) {
+        this.tokenNumUses = tokenNumUses;
+        return this;
+    }
+
+    /**
+     * Set token period.
+     *
+     * @param tokenPeriod token period
+     * @return self
+     */
+    public TokenRoleBuilder withTokenPeriod(final Integer tokenPeriod) {
+        this.tokenPeriod = tokenPeriod;
+        return this;
+    }
+
+    /**
+     * Set token type.
+     *
+     * @param tokenType token type
+     * @return self
+     */
+    public TokenRoleBuilder withTokenType(final Token.Type tokenType) {
+        this.tokenType = tokenType;
+        return this;
+    }
+
+    /**
+     * Build the token based on given parameters.
+     *
+     * @return the token
+     */
+    public TokenRole build() {
+        return new TokenRole(
+                null,
+                allowedPolicies,
+                disallowedPolicies,
+                orphan,
+                renewable,
+                pathSuffix,
+                allowedEntityAliases,
+                tokenBoundCidrs,
+                tokenExplicitMaxTtl,
+                tokenNoDefaultPolicy,
+                tokenNumUses,
+                tokenPeriod,
+                tokenType != null ? tokenType.value() : null
+        );
+    }
+}

--- a/src/main/java/de/stklcode/jvault/connector/model/TokenRoleBuilder.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/TokenRoleBuilder.java
@@ -26,6 +26,7 @@ import java.util.List;
  * @since 0.9
  */
 public final class TokenRoleBuilder {
+    private String name;
     private List<String> allowedPolicies;
     private List<String> disallowedPolicies;
     private Boolean orphan;
@@ -38,6 +39,17 @@ public final class TokenRoleBuilder {
     private Integer tokenNumUses;
     private Integer tokenPeriod;
     private Token.Type tokenType;
+
+    /**
+     * Add token role name.
+     *
+     * @param name role name
+     * @return self
+     */
+    public TokenRoleBuilder forName(final String name) {
+        this.name = name;
+        return this;
+    }
 
     /**
      * Add an allowed policy.
@@ -262,7 +274,7 @@ public final class TokenRoleBuilder {
      */
     public TokenRole build() {
         return new TokenRole(
-                null,
+                name,
                 allowedPolicies,
                 disallowedPolicies,
                 orphan,

--- a/src/main/java/de/stklcode/jvault/connector/model/response/TokenRoleResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/TokenRoleResponse.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2020 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import de.stklcode.jvault.connector.model.TokenRole;
+import de.stklcode.jvault.connector.model.response.embedded.TokenData;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Vault response from token role lookup providing Token information in {@link TokenData} field.
+ *
+ * @author Stefan Kalscheuer
+ * @since 0.9
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class TokenRoleResponse extends VaultDataResponse {
+    private TokenRole data;
+
+    /**
+     * Set data. Parses response data map to {@link TokenRole}.
+     *
+     * @param data Raw response data
+     * @throws InvalidResponseException on parsing errors
+     */
+    @Override
+    public void setData(final Map<String, Object> data) throws InvalidResponseException {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            this.data = mapper.readValue(mapper.writeValueAsString(data), TokenRole.class);
+        } catch (IOException e) {
+            throw new InvalidResponseException("Failed deserializing response", e);
+        }
+    }
+
+    /**
+     * @return TokenRole data
+     */
+    public TokenRole getData() {
+        return data;
+    }
+}

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenRoleBuilderTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenRoleBuilderTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.*;
  * @since 0.9
  */
 public class TokenRoleBuilderTest {
+    private static final String NAME = "test-role";
     private static final String ALLOWED_POLICY_1 = "apol-1";
     private static final String ALLOWED_POLICY_2 = "apol-2";
     private static final String ALLOWED_POLICY_3 = "apol-3";
@@ -59,6 +60,7 @@ public class TokenRoleBuilderTest {
     private static final Token.Type TOKEN_TYPE = Token.Type.SERVICE;
 
     private static final String JSON_FULL = "{" +
+            "\"name\":\"" + NAME + "\"," +
             "\"allowed_policies\":[\"" + ALLOWED_POLICY_1 + "\",\"" + ALLOWED_POLICY_2 + "\",\"" + ALLOWED_POLICY_3 + "\"]," +
             "\"disallowed_policies\":[\"" + DISALLOWED_POLICY_1 + "\",\"" + DISALLOWED_POLICY_2 + "\",\"" + DISALLOWED_POLICY_3 + "\"]," +
             "\"orphan\":" + ORPHAN + "," +
@@ -100,6 +102,7 @@ public class TokenRoleBuilderTest {
     @Test
     public void buildNullTest() throws JsonProcessingException {
         TokenRole role = TokenRole.builder()
+                .forName(null)
                 .withAllowedPolicies(null)
                 .withAllowedPolicy(null)
                 .withDisallowedPolicy(null)
@@ -140,6 +143,7 @@ public class TokenRoleBuilderTest {
     @Test
     public void buildFullTest() throws JsonProcessingException {
         TokenRole role = TokenRole.builder()
+                .forName(NAME)
                 .withAllowedPolicies(ALLOWED_POLICIES)
                 .withAllowedPolicy(ALLOWED_POLICY_3)
                 .withDisallowedPolicy(DISALLOWED_POLICY_1)
@@ -157,7 +161,7 @@ public class TokenRoleBuilderTest {
                 .withTokenPeriod(TOKEN_PERIOD)
                 .withTokenType(TOKEN_TYPE)
                 .build();
-        assertThat(role.getName(), is(nullValue()));
+        assertThat(role.getName(), is(NAME));
         assertThat(role.getAllowedPolicies(), hasSize(ALLOWED_POLICIES.size() + 1));
         assertThat(role.getAllowedPolicies(), containsInAnyOrder(ALLOWED_POLICY_1, ALLOWED_POLICY_2, ALLOWED_POLICY_3));
         assertThat(role.getDisallowedPolicies(), hasSize(DISALLOWED_POLICIES.size() + 1));

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenRoleBuilderTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenRoleBuilderTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016-2020 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Unit Test for {@link TokenRoleBuilder}
+ *
+ * @author Stefan Kalscheuer
+ * @since 0.9
+ */
+public class TokenRoleBuilderTest {
+    private static final String ALLOWED_POLICY_1 = "apol-1";
+    private static final String ALLOWED_POLICY_2 = "apol-2";
+    private static final String ALLOWED_POLICY_3 = "apol-3";
+    private static final List<String> ALLOWED_POLICIES = Arrays.asList(ALLOWED_POLICY_1, ALLOWED_POLICY_2);
+    private static final String DISALLOWED_POLICY_1 = "dpol-1";
+    private static final String DISALLOWED_POLICY_2 = "dpol-2";
+    private static final String DISALLOWED_POLICY_3 = "dpol-3";
+    private static final List<String> DISALLOWED_POLICIES = Arrays.asList(DISALLOWED_POLICY_2, DISALLOWED_POLICY_3);
+    private static final Boolean ORPHAN = false;
+    private static final Boolean RENEWABLE = true;
+    private static final String PATH_SUFFIX = "ps";
+    private static final String ALLOWED_ENTITY_ALIAS_1 = "alias-1";
+    private static final String ALLOWED_ENTITY_ALIAS_2 = "alias-2";
+    private static final String ALLOWED_ENTITY_ALIAS_3 = "alias-3";
+    private static final List<String> ALLOWED_ENTITY_ALIASES = Arrays.asList(ALLOWED_ENTITY_ALIAS_1, ALLOWED_ENTITY_ALIAS_3);
+    private static final String TOKEN_BOUND_CIDR_1 = "192.0.2.0/24";
+    private static final String TOKEN_BOUND_CIDR_2 = "198.51.100.0/24";
+    private static final String TOKEN_BOUND_CIDR_3 = "203.0.113.0/24";
+    private static final List<String> TOKEN_BOUND_CIDRS = Arrays.asList(TOKEN_BOUND_CIDR_2, TOKEN_BOUND_CIDR_1);
+    private static final Integer TOKEN_EXPLICIT_MAX_TTL = 1234;
+    private static final Boolean TOKEN_NO_DEFAULT_POLICY = false;
+    private static final Integer TOKEN_NUM_USES = 5;
+    private static final Integer TOKEN_PERIOD = 2345;
+    private static final Token.Type TOKEN_TYPE = Token.Type.SERVICE;
+
+    private static final String JSON_FULL = "{" +
+            "\"allowed_policies\":[\"" + ALLOWED_POLICY_1 + "\",\"" + ALLOWED_POLICY_2 + "\",\"" + ALLOWED_POLICY_3 + "\"]," +
+            "\"disallowed_policies\":[\"" + DISALLOWED_POLICY_1 + "\",\"" + DISALLOWED_POLICY_2 + "\",\"" + DISALLOWED_POLICY_3 + "\"]," +
+            "\"orphan\":" + ORPHAN + "," +
+            "\"renewable\":" + RENEWABLE + "," +
+            "\"path_suffix\":\"" + PATH_SUFFIX + "\"," +
+            "\"allowed_entity_aliases\":[\"" + ALLOWED_ENTITY_ALIAS_1 + "\",\"" + ALLOWED_ENTITY_ALIAS_3 + "\",\"" + ALLOWED_ENTITY_ALIAS_2 + "\"]," +
+            "\"token_bound_cidrs\":[\"" + TOKEN_BOUND_CIDR_3 + "\",\"" + TOKEN_BOUND_CIDR_2 + "\",\"" + TOKEN_BOUND_CIDR_1 + "\"]," +
+            "\"token_explicit_max_ttl\":" + TOKEN_EXPLICIT_MAX_TTL + "," +
+            "\"token_no_default_policy\":" + TOKEN_NO_DEFAULT_POLICY + "," +
+            "\"token_num_uses\":" + TOKEN_NUM_USES + "," +
+            "\"token_period\":" + TOKEN_PERIOD + "," +
+            "\"token_type\":\"" + TOKEN_TYPE.value() + "\"}";
+
+    /**
+     * Build token without any parameters.
+     */
+    @Test
+    public void buildDefaultTest() throws JsonProcessingException {
+        TokenRole role = new TokenRoleBuilder().build();
+        assertThat(role.getAllowedPolicies(), is(nullValue()));
+        assertThat(role.getDisallowedPolicies(), is(nullValue()));
+        assertThat(role.getOrphan(), is(nullValue()));
+        assertThat(role.getRenewable(), is(nullValue()));
+        assertThat(role.getAllowedEntityAliases(), is(nullValue()));
+        assertThat(role.getTokenBoundCidrs(), is(nullValue()));
+        assertThat(role.getTokenExplicitMaxTtl(), is(nullValue()));
+        assertThat(role.getTokenNoDefaultPolicy(), is(nullValue()));
+        assertThat(role.getTokenNumUses(), is(nullValue()));
+        assertThat(role.getTokenPeriod(), is(nullValue()));
+        assertThat(role.getTokenType(), is(nullValue()));
+
+        /* optional fields should be ignored, so JSON string should be empty */
+        assertThat(new ObjectMapper().writeValueAsString(role), is("{}"));
+    }
+
+    /**
+     * Build token without all parameters NULL.
+     */
+    @Test
+    public void buildNullTest() throws JsonProcessingException {
+        TokenRole role = TokenRole.builder()
+                .withAllowedPolicies(null)
+                .withAllowedPolicy(null)
+                .withDisallowedPolicy(null)
+                .withDisallowedPolicies(null)
+                .orphan(null)
+                .renewable(null)
+                .withPathSuffix(null)
+                .withAllowedEntityAliases(null)
+                .withAllowedEntityAlias(null)
+                .withTokenBoundCidr(null)
+                .withTokenBoundCidrs(null)
+                .withTokenExplicitMaxTtl(null)
+                .withTokenNoDefaultPolicy(null)
+                .withTokenNumUses(null)
+                .withTokenPeriod(null)
+                .withTokenType(null)
+                .build();
+
+        assertThat(role.getAllowedPolicies(), is(nullValue()));
+        assertThat(role.getDisallowedPolicies(), is(nullValue()));
+        assertThat(role.getOrphan(), is(nullValue()));
+        assertThat(role.getRenewable(), is(nullValue()));
+        assertThat(role.getAllowedEntityAliases(), is(nullValue()));
+        assertThat(role.getTokenBoundCidrs(), is(nullValue()));
+        assertThat(role.getTokenExplicitMaxTtl(), is(nullValue()));
+        assertThat(role.getTokenNoDefaultPolicy(), is(nullValue()));
+        assertThat(role.getTokenNumUses(), is(nullValue()));
+        assertThat(role.getTokenPeriod(), is(nullValue()));
+        assertThat(role.getTokenType(), is(nullValue()));
+
+        /* optional fields should be ignored, so JSON string should be empty */
+        assertThat(new ObjectMapper().writeValueAsString(role), is("{}"));
+    }
+
+    /**
+     * Build token without all parameters set.
+     */
+    @Test
+    public void buildFullTest() throws JsonProcessingException {
+        TokenRole role = TokenRole.builder()
+                .withAllowedPolicies(ALLOWED_POLICIES)
+                .withAllowedPolicy(ALLOWED_POLICY_3)
+                .withDisallowedPolicy(DISALLOWED_POLICY_1)
+                .withDisallowedPolicies(DISALLOWED_POLICIES)
+                .orphan(ORPHAN)
+                .renewable(RENEWABLE)
+                .withPathSuffix(PATH_SUFFIX)
+                .withAllowedEntityAliases(ALLOWED_ENTITY_ALIASES)
+                .withAllowedEntityAlias(ALLOWED_ENTITY_ALIAS_2)
+                .withTokenBoundCidr(TOKEN_BOUND_CIDR_3)
+                .withTokenBoundCidrs(TOKEN_BOUND_CIDRS)
+                .withTokenExplicitMaxTtl(TOKEN_EXPLICIT_MAX_TTL)
+                .withTokenNoDefaultPolicy(TOKEN_NO_DEFAULT_POLICY)
+                .withTokenNumUses(TOKEN_NUM_USES)
+                .withTokenPeriod(TOKEN_PERIOD)
+                .withTokenType(TOKEN_TYPE)
+                .build();
+        assertThat(role.getName(), is(nullValue()));
+        assertThat(role.getAllowedPolicies(), hasSize(ALLOWED_POLICIES.size() + 1));
+        assertThat(role.getAllowedPolicies(), containsInAnyOrder(ALLOWED_POLICY_1, ALLOWED_POLICY_2, ALLOWED_POLICY_3));
+        assertThat(role.getDisallowedPolicies(), hasSize(DISALLOWED_POLICIES.size() + 1));
+        assertThat(role.getDisallowedPolicies(), containsInAnyOrder(DISALLOWED_POLICY_1, DISALLOWED_POLICY_2, DISALLOWED_POLICY_3));
+        assertThat(role.getOrphan(), is(ORPHAN));
+        assertThat(role.getRenewable(), is(RENEWABLE));
+        assertThat(role.getPathSuffix(), is(PATH_SUFFIX));
+        assertThat(role.getAllowedEntityAliases(), hasSize(ALLOWED_ENTITY_ALIASES.size() + 1));
+        assertThat(role.getAllowedEntityAliases(), containsInAnyOrder(ALLOWED_ENTITY_ALIAS_1, ALLOWED_ENTITY_ALIAS_2, ALLOWED_ENTITY_ALIAS_3));
+        assertThat(role.getTokenBoundCidrs(), hasSize(TOKEN_BOUND_CIDRS.size() + 1));
+        assertThat(role.getTokenBoundCidrs(), containsInAnyOrder(TOKEN_BOUND_CIDR_1, TOKEN_BOUND_CIDR_2, TOKEN_BOUND_CIDR_3));
+        assertThat(role.getTokenNoDefaultPolicy(), is(TOKEN_NO_DEFAULT_POLICY));
+        assertThat(role.getTokenNumUses(), is(TOKEN_NUM_USES));
+        assertThat(role.getTokenPeriod(), is(TOKEN_PERIOD));
+        assertThat(role.getTokenType(), is(TOKEN_TYPE.value()));
+
+        /* Verify that all parameters are included in JSON string */
+        assertThat(new ObjectMapper().writeValueAsString(role), is(JSON_FULL));
+    }
+}


### PR DESCRIPTION
Add support for _Token Role_ handling (closes #27)

Introduces methods (naming should be self-explanatory)
* `boolean createOrUpdateTokenRole(String, TokenRole)`
`boolean createOrUpdateTokenRole(TokenRole)`
* `TokenRoleResponse readTokenRole(String)`
* `boolean deleteTokenRole(String)`
* `List<String> listTokenRoles()`

Token roles can be created using a newly introduced builder
```java
TokenRole tr = TokenRole.builder().build();
 ```