### PR TITLE
add missing fields to Token model and builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Improvements
 * Added `entity_id`, `token_policies`, `token_type` and `orphan` flags to auth response
 * Added `entity_id`, `expire_time`, `explicit_max_ttl`, `issue_time`, `renewable` and `type` flags to token data
+* Added `explicit_max_ttl`, `period` and `entity_alias` flags to _Token_ model (#41)
 * Added `enable_local_secret_ids`, `token_bound_cidrs`, `token_explicit_max_ttl`, `token_no_default_policy`, 
   `token_num_uses`, `token_period` and `token_type` flags to _AppRole_ model
 * Minor dependency updates

--- a/src/main/java/de/stklcode/jvault/connector/model/Token.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/Token.java
@@ -64,6 +64,10 @@ public final class Token {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer ttl;
 
+    @JsonProperty("explicit_max_ttl")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer explicitMaxTtl;
+
     @JsonProperty("num_uses")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer numUses;
@@ -79,6 +83,14 @@ public final class Token {
     @JsonProperty("renewable")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean renewable;
+
+    @JsonProperty("period")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer period;
+
+    @JsonProperty("entity_alias")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String entityAlias;
 
     /**
      * Construct empty {@link Token} object.
@@ -163,10 +175,13 @@ public final class Token {
         this.noParent = builder.noParent;
         this.noDefaultPolicy = builder.noDefaultPolicy;
         this.ttl = builder.ttl;
+        this.explicitMaxTtl = builder.explicitMaxTtl;
         this.numUses = builder.numUses;
         this.policies = builder.policies;
         this.meta = builder.meta;
         this.renewable = builder.renewable;
+        this.period = builder.period;
+        this.entityAlias = builder.entityAlias;
     }
 
     /**
@@ -213,6 +228,14 @@ public final class Token {
     }
 
     /**
+     * @return Explicit maximum time-to-live in seconds
+     * @since 0.9
+     */
+    public Integer getExplicitMaxTtl() {
+        return explicitMaxTtl;
+    }
+
+    /**
      * @return Number of uses
      */
     public Integer getNumUses() {
@@ -238,6 +261,22 @@ public final class Token {
      */
     public Boolean isRenewable() {
         return renewable;
+    }
+
+    /**
+     * @return Token period.
+     * @since 0.9
+     */
+    public Integer getPeriod() {
+        return period;
+    }
+
+    /**
+     * @return Token entity alias.
+     * @since 0.9
+     */
+    public String getEntityAlias() {
+        return entityAlias;
     }
 
     /**
@@ -276,10 +315,13 @@ public final class Token {
         private Boolean noParent;
         private Boolean noDefaultPolicy;
         private Integer ttl;
+        private Integer explicitMaxTtl;
         private Integer numUses;
         private List<String> policies;
         private Map<String, String> meta;
         private Boolean renewable;
+        private Integer period;
+        private String entityAlias;
 
         /**
          * Add token ID. (optional)
@@ -323,6 +365,17 @@ public final class Token {
          */
         public Builder withTtl(final Integer ttl) {
             this.ttl = ttl;
+            return this;
+        }
+
+        /**
+         * Set desired explicit maximum time to live.
+         *
+         * @param explicitMaxTtl the explicit max. TTL
+         * @return self
+         */
+        public Builder withExplicitMaxTtl(final Integer explicitMaxTtl) {
+            this.explicitMaxTtl = explicitMaxTtl;
             return this;
         }
 
@@ -496,6 +549,27 @@ public final class Token {
          */
         public Builder notRenewable() {
             return withRenewable(false);
+        }
+
+        /**
+         * Set token period (former lease time).
+         *
+         * @return self
+         */
+        public Builder withPeriod(final Integer period) {
+            this.period = period;
+            return this;
+        }
+
+        /**
+         * Set entity alias for token.
+         * Only works in combination with an associated token role.
+         *
+         * @return self
+         */
+        public Builder withEntityAlias(final String entityAlias) {
+            this.entityAlias = entityAlias;
+            return this;
         }
 
         /**

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenBuilderTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenBuilderTest.java
@@ -36,12 +36,12 @@ import static org.hamcrest.Matchers.*;
  * @since 0.4.0
  */
 public class TokenBuilderTest {
-
     private static final String ID = "test-id";
     private static final String DISPLAY_NAME = "display-name";
     private static final Boolean NO_PARENT = false;
     private static final Boolean NO_DEFAULT_POLICY = false;
     private static final Integer TTL = 123;
+    private static final Integer EXPLICIT_MAX_TTL = 456;
     private static final Integer NUM_USES = 4;
     private static final List<String> POLICIES = new ArrayList<>();
     private static final String POLICY = "policy";
@@ -53,7 +53,10 @@ public class TokenBuilderTest {
     private static final String META_KEY_2 = "key2";
     private static final String META_VALUE_2 = "value2";
     private static final Boolean RENEWABLE = true;
-    private static final String JSON_FULL = "{\"id\":\"test-id\",\"type\":\"service\",\"display_name\":\"display-name\",\"no_parent\":false,\"no_default_policy\":false,\"ttl\":123,\"num_uses\":4,\"policies\":[\"policy\"],\"meta\":{\"key\":\"value\"},\"renewable\":true}";
+    private static final Integer PERIOD = 3600;
+    private static final String ENTITY_ALIAS = "alias-value";
+    private static final String LEGACY_JSON_FULL = "{\"id\":\"test-id\",\"type\":\"service\",\"display_name\":\"display-name\",\"no_parent\":false,\"no_default_policy\":false,\"ttl\":123,\"num_uses\":4,\"policies\":[\"policy\"],\"meta\":{\"key\":\"value\"},\"renewable\":true}";
+    private static final String JSON_FULL = "{\"id\":\"test-id\",\"type\":\"service\",\"display_name\":\"display-name\",\"no_parent\":false,\"no_default_policy\":false,\"ttl\":123,\"explicit_max_ttl\":456,\"num_uses\":4,\"policies\":[\"policy\"],\"meta\":{\"key\":\"value\"},\"renewable\":true,\"period\":3600,\"entity_alias\":\"alias-value\"}";
 
     @BeforeAll
     public static void init() {
@@ -73,10 +76,13 @@ public class TokenBuilderTest {
         assertThat(token.getNoParent(), is(nullValue()));
         assertThat(token.getNoDefaultPolicy(), is(nullValue()));
         assertThat(token.getTtl(), is(nullValue()));
+        assertThat(token.getExplicitMaxTtl(), is(nullValue()));
         assertThat(token.getNumUses(), is(nullValue()));
         assertThat(token.getPolicies(), is(nullValue()));
         assertThat(token.getMeta(), is(nullValue()));
         assertThat(token.isRenewable(), is(nullValue()));
+        assertThat(token.getPeriod(), is(nullValue()));
+        assertThat(token.getEntityAlias(), is(nullValue()));
 
         /* optional fields should be ignored, so JSON string should be empty */
         assertThat(new ObjectMapper().writeValueAsString(token), is("{}"));
@@ -115,10 +121,13 @@ public class TokenBuilderTest {
                 .withNoParent(NO_PARENT)
                 .withNoDefaultPolicy(NO_DEFAULT_POLICY)
                 .withTtl(TTL)
+                .withExplicitMaxTtl(EXPLICIT_MAX_TTL)
                 .withNumUses(NUM_USES)
                 .withPolicies(POLICIES)
                 .withMeta(META)
                 .withRenewable(RENEWABLE)
+                .withPeriod(PERIOD)
+                .withEntityAlias(ENTITY_ALIAS)
                 .build();
         assertThat(token.getId(), is(ID));
         assertThat(token.getType(), is(Token.Type.SERVICE.value()));
@@ -126,10 +135,12 @@ public class TokenBuilderTest {
         assertThat(token.getNoParent(), is(NO_PARENT));
         assertThat(token.getNoDefaultPolicy(), is(NO_DEFAULT_POLICY));
         assertThat(token.getTtl(), is(TTL));
+        assertThat(token.getExplicitMaxTtl(), is(EXPLICIT_MAX_TTL));
         assertThat(token.getNumUses(), is(NUM_USES));
         assertThat(token.getPolicies(), is(POLICIES));
         assertThat(token.getMeta(), is(META));
         assertThat(token.isRenewable(), is(RENEWABLE));
+        assertThat(token.getPeriod(), is(PERIOD));
 
         /* Verify that all parameters are included in JSON string */
         assertThat(new ObjectMapper().writeValueAsString(token), is(JSON_FULL));
@@ -164,7 +175,7 @@ public class TokenBuilderTest {
         assertThat(token.isRenewable(), is(RENEWABLE));
 
         /* Verify that all parameters are included in JSON string */
-        assertThat(new ObjectMapper().writeValueAsString(token), is(JSON_FULL));
+        assertThat(new ObjectMapper().writeValueAsString(token), is(LEGACY_JSON_FULL));
     }
 
     /**


### PR DESCRIPTION
Adds missing fiields up to Vault 1.4 to Token model and builder:
* `explicit_max_ttl`
* `period`
* `entity_alias`