### PR TITLE
only initialize trust managers if CA certificate is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+### Fixes
+* Only initialize custom trust managers, if CA certificate is actually provided (#43)
+
 ## 0.9.1 (2021-01-03)
 
 ### Improvements

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.stklcode.jvault</groupId>
     <artifactId>jvault-connector</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
+++ b/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
@@ -367,18 +367,22 @@ public final class RequestHelper implements Serializable {
      */
     private SSLConnectionSocketFactory createSSLSocketFactory() throws TlsException {
         try {
-            // Create Keystore with trusted certificate.
-            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-            keyStore.load(null, null);
-            keyStore.setCertificateEntry("trustedCert", trustedCaCert);
-
-            // Initialize TrustManager.
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(keyStore);
-
-            // Create context using this TrustManager.
+            // Create context..
             SSLContext context = SSLContext.getInstance(tlsVersion);
-            context.init(null, tmf.getTrustManagers(), new SecureRandom());
+
+            if (trustedCaCert != null) {
+                // Create Keystore with trusted certificate.
+                KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+                keyStore.load(null, null);
+                keyStore.setCertificateEntry("trustedCert", trustedCaCert);
+
+                // Initialize TrustManager.
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                tmf.init(keyStore);
+                context.init(null, tmf.getTrustManagers(), null);
+            } else {
+                context.init(null, null, null);
+            }
 
             return new SSLConnectionSocketFactory(
                     context,


### PR DESCRIPTION
Trust anchors `null` will raise an `InvalidAlgorithmParameterException` ...