### PR TITLE
Migrate HTTP transport to Java 11 HTTP (#44)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 
 jobs:
   include:
-    - jdk: openjdk8
     - jdk: openjdk11
       env: PATH=$PATH:. VAULT_VERSION=1.7.0 ANALYSIS=true
     - jdk: openjdk16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## unreleased
+
+### Breaking
+* Requires Java 11 or later
+
+### Improvements
+* Use pre-sized map objects for fixed-size payloads
+* Remove Apache HTTP Client dependency in favor of Java 11 HTTP
+
+
 ## 0.9.3 (2021-04-02)
 
 ### Improvements

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.stklcode.jvault</groupId>
     <artifactId>jvault-connector</artifactId>
-    <version>0.9.3</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -52,8 +52,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -202,7 +202,7 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.2.0</version>
                         <configuration>
-                            <source>1.8</source>
+                            <source>11</source>
                         </configuration>
                         <executions>
                             <execution>
@@ -304,26 +304,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>jdk1.8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <argLine>@{argLine}</argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
             </build>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.12.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -130,15 +130,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>3.8.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-lambda</artifactId>
             <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.27.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/de/stklcode/jvault/connector/internal/Error.java
+++ b/src/main/java/de/stklcode/jvault/connector/internal/Error.java
@@ -29,6 +29,7 @@ final class Error {
     static final String URI_FORMAT = "Invalid URI format";
     static final String RESPONSE_CODE = "Invalid response code";
     static final String INIT_SSL_CONTEXT = "Unable to initialize SSLContext";
+    static final String CONNECTION = "Unable to connect to Vault server";
 
     /**
      * Constructor hidden, this class should not be instantiated.


### PR DESCRIPTION
closes #44

Raise Java language level and replace Apache HTTP library with native JDK 11 HTTP.

Public API unchanged (despite the Java requirement obviously), as most logic was already bundled in the internal `RequestHelper` class.

Static mocks are replaced by _WireMock_ for offline tests.