### PR TITLE
fix typo in method AppRole.Builder#wit0hTokenPeriod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+### Deprecations
+* `AppRole.Builder#wit0hTokenPeriod()` is deprecated in favor of `#withTokenPeriod()`
+
 ## 0.9.3 (2021-04-02)
 
 ### Improvements

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.stklcode.jvault</groupId>
     <artifactId>jvault-connector</artifactId>
-    <version>0.9.3</version>
+    <version>0.9.4-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
@@ -703,7 +703,7 @@ public final class AppRole {
          * @return self
          * @since 0.9
          */
-        public Builder wit0hTokenPeriod(final Integer tokenPeriod) {
+        public Builder withTokenPeriod(final Integer tokenPeriod) {
             this.tokenPeriod = tokenPeriod;
             return this;
         }
@@ -711,13 +711,26 @@ public final class AppRole {
         /**
          * Set renewal period for generated token in seconds.
          *
+         * @param tokenPeriod period in seconds
+         * @return self
+         * @since 0.9
+         * @deprecated Use {@link #withTokenPeriod(Integer)} instead.
+         */
+        @Deprecated
+        public Builder wit0hTokenPeriod(final Integer tokenPeriod) {
+            return withTokenPeriod(tokenPeriod);
+        }
+
+        /**
+         * Set renewal period for generated token in seconds.
+         *
          * @param period period in seconds
          * @return self
-         * @deprecated Use {@link #wit0hTokenPeriod(Integer)} instead.
+         * @deprecated Use {@link #withTokenPeriod(Integer)} instead.
          */
         @Deprecated
         public Builder withPeriod(final Integer period) {
-            return wit0hTokenPeriod(period);
+            return withTokenPeriod(period);
         }
 
         /**

--- a/src/main/java/de/stklcode/jvault/connector/model/AppRoleBuilder.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/AppRoleBuilder.java
@@ -308,7 +308,7 @@ public final class AppRoleBuilder {
      * @return self
      * @since 0.9
      */
-    public AppRoleBuilder wit0hTokenPeriod(final Integer tokenPeriod) {
+    public AppRoleBuilder withTokenPeriod(final Integer tokenPeriod) {
         this.tokenPeriod = tokenPeriod;
         return this;
     }
@@ -316,13 +316,26 @@ public final class AppRoleBuilder {
     /**
      * Set renewal period for generated token in seconds.
      *
+     * @param tokenPeriod period in seconds
+     * @return self
+     * @since 0.9
+     * @deprecated Use {@link #withTokenPeriod(Integer)} instead.
+     */
+    @Deprecated
+    public AppRoleBuilder wit0hTokenPeriod(final Integer tokenPeriod) {
+        return withTokenPeriod(tokenPeriod);
+    }
+
+    /**
+     * Set renewal period for generated token in seconds.
+     *
      * @param period period in seconds
      * @return self
-     * @deprecated Use {@link #wit0hTokenPeriod(Integer)} instead.
+     * @deprecated Use {@link #withTokenPeriod(Integer)} instead.
      */
     @Deprecated
     public AppRoleBuilder withPeriod(final Integer period) {
-        return wit0hTokenPeriod(period);
+        return withTokenPeriod(period);
     }
 
     /**

--- a/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorTest.java
@@ -771,7 +771,7 @@ class HTTPVaultConnectorTest {
 
             /* Update role model with custom flags */
             AppRole role2 = AppRole.builder(roleName)
-                    .wit0hTokenPeriod(321)
+                    .withTokenPeriod(321)
                     .build();
 
             /* Create role */

--- a/src/test/java/de/stklcode/jvault/connector/model/AppRoleBuilderTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AppRoleBuilderTest.java
@@ -138,7 +138,7 @@ class AppRoleBuilderTest {
                 .withTokenExplicitMaxTtl(TOKEN_EXPLICIT_MAX_TTL)
                 .withTokenNoDefaultPolicy(TOKEN_NO_DEFAULT_POLICY)
                 .withTokenNumUses(TOKEN_NUM_USES)
-                .wit0hTokenPeriod(TOKEN_PERIOD)
+                .withTokenPeriod(TOKEN_PERIOD)
                 .withTokenType(TOKEN_TYPE)
                 .build();
         assertThat(role.getName(), is(NAME));
@@ -183,7 +183,7 @@ class AppRoleBuilderTest {
                 .withTokenExplicitMaxTtl(TOKEN_EXPLICIT_MAX_TTL)
                 .withTokenNoDefaultPolicy(TOKEN_NO_DEFAULT_POLICY)
                 .withTokenNumUses(TOKEN_NUM_USES)
-                .wit0hTokenPeriod(TOKEN_PERIOD)
+                .withTokenPeriod(TOKEN_PERIOD)
                 .withTokenType(TOKEN_TYPE)
                 .build();
         assertThat(role.getName(), is(NAME));


### PR DESCRIPTION
Introduce `AppRole.Builder#withTokenPeriod()` and deprecate `#wit0hTokenPeriod` with typo.