### PR TITLE
passthrough null as port number in builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+### Fix
+* Make `HTTPVaultConnectorBuilder#withPort(Integer)` null-safe (#56)
+
+
 ## 1.0.0 (2021-10-02)
 
 ### Breaking

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.stklcode.jvault</groupId>
     <artifactId>jvault-connector</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilder.java
+++ b/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilder.java
@@ -125,13 +125,13 @@ public final class HTTPVaultConnectorBuilder {
     /**
      * Set port (default: 8200).
      * A value of {@code null} or {@code -1} indicates that no port is specified, i.e. the protocol default is used.
-     * Otherwise a valid port number bwetween 1 and 65535 is expected.
+     * Otherwise, a valid port number between 1 and 65535 is expected.
      *
      * @param port Vault TCP port
      * @return self
      */
     public HTTPVaultConnectorBuilder withPort(final Integer port) {
-        if (port < 0) {
+        if (port == null || port < 0) {
             this.port = null;
         } else if (port < 1 || port > 65535) {
             throw new IllegalArgumentException("Port number " + port + " out of range");

--- a/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilderTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilderTest.java
@@ -89,6 +89,8 @@ class HTTPVaultConnectorBuilderTest {
         assertThrows(IllegalArgumentException.class, () -> HTTPVaultConnector.builder().withPort(0), "Port number 0 should throw an exception");
         builder = assertDoesNotThrow(() -> HTTPVaultConnector.builder().withPort(-1), "Port number -1 should not throw an exception");
         assertNull(builder.getPort(), "Port number -1 should be omitted");
+        builder = assertDoesNotThrow(() -> HTTPVaultConnector.builder().withPort(null), "Port number NULL should not throw an exception");
+        assertNull(builder.getPort(), "Port number NULL should be passed through");
     }
 
     /**


### PR DESCRIPTION
### Problem

Port number `null` should be passed through. We actively set `null`, if values below zero as given to use the default port.

Even if this is explicitly stated in the Javadocs, the current implementation raises a `NullPointerException` in this case, s.t. systems that auto-provision the client with optional port number have to care about the fallback to 8200 themselves.

### Solution

Passthrough `null` in `HTTPVaultConnectorBuilder#withPort(Integer)`.