### PR TITLE
make model classes implement Serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add support for `wrap_info` in data response models
 * Dependency updates
 * model and response classes implement `Serializable` (#57)
+* split `SercretResponse`  into `PlainSecretResponse` and `MetaSecretResponse` subclasses (common API unchanged)
 
 ### Test
 * Tested against Vault 1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `migration`, `recovery_seal` and `storage_type` fields to `SealReponse` model
 * Add support for `wrap_info` in data response models
 * Dependency updates
+* model and response classes implement `Serializable` (#57)
 
 ### Test
 * Tested against Vault 1.10.0

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
             <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>3.9</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
@@ -411,7 +411,7 @@ public class HTTPVaultConnector implements VaultConnector {
     public final SecretResponse read(final String key) throws VaultConnectorException {
         requireAuth();
         /* Issue request and parse secret response */
-        return request.get(key, emptyMap(), token, SecretResponse.class);
+        return request.get(key, emptyMap(), token, PlainSecretResponse.class);
     }
 
     @Override
@@ -423,7 +423,7 @@ public class HTTPVaultConnector implements VaultConnector {
             args.put("version", version.toString());
         }
 
-        return request.get(mount + PATH_DATA + key, args, token, SecretResponse.class);
+        return request.get(mount + PATH_DATA + key, args, token, MetaSecretResponse.class);
     }
 
     @Override

--- a/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
@@ -18,17 +18,22 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.annotation.*;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Vault AppRole role metamodel.
  *
  * @author Stefan Kalscheuer
  * @since 0.4.0
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class AppRole {
+public final class AppRole implements Serializable {
+    private static final long serialVersionUID = -6248529625864573990L;
+
     /**
      * Get {@link Builder} instance.
      *
@@ -314,6 +319,39 @@ public final class AppRole {
      */
     public String getTokenType() {
         return tokenType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AppRole appRole = (AppRole) o;
+        return Objects.equals(name, appRole.name) &&
+                Objects.equals(id, appRole.id) &&
+                Objects.equals(bindSecretId, appRole.bindSecretId) &&
+                Objects.equals(secretIdBoundCidrs, appRole.secretIdBoundCidrs) &&
+                Objects.equals(secretIdNumUses, appRole.secretIdNumUses) &&
+                Objects.equals(secretIdTtl, appRole.secretIdTtl) &&
+                Objects.equals(enableLocalSecretIds, appRole.enableLocalSecretIds) &&
+                Objects.equals(tokenTtl, appRole.tokenTtl) &&
+                Objects.equals(tokenMaxTtl, appRole.tokenMaxTtl) &&
+                Objects.equals(tokenPolicies, appRole.tokenPolicies) &&
+                Objects.equals(tokenBoundCidrs, appRole.tokenBoundCidrs) &&
+                Objects.equals(tokenExplicitMaxTtl, appRole.tokenExplicitMaxTtl) &&
+                Objects.equals(tokenNoDefaultPolicy, appRole.tokenNoDefaultPolicy) &&
+                Objects.equals(tokenNumUses, appRole.tokenNumUses) &&
+                Objects.equals(tokenPeriod, appRole.tokenPeriod) &&
+                Objects.equals(tokenType, appRole.tokenType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, id, bindSecretId, secretIdBoundCidrs, secretIdNumUses, secretIdTtl,
+                enableLocalSecretIds, tokenTtl, tokenMaxTtl, tokenPolicies, tokenBoundCidrs, tokenExplicitMaxTtl,
+                tokenNoDefaultPolicy, tokenNumUses, tokenPeriod, tokenType);
     }
 
 

--- a/src/main/java/de/stklcode/jvault/connector/model/AppRoleSecret.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/AppRoleSecret.java
@@ -18,17 +18,22 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.annotation.*;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault AppRole role metamodel.
  *
  * @author Stefan Kalscheuer
  * @since 0.4.0
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class AppRoleSecret {
+public final class AppRoleSecret implements Serializable {
+    private static final long serialVersionUID = -3401074170145792641L;
+
     @JsonProperty("secret_id")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String id;
@@ -165,5 +170,30 @@ public final class AppRoleSecret {
      */
     public Integer getTtl() {
         return ttl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AppRoleSecret that = (AppRoleSecret) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(accessor, that.accessor) &&
+                Objects.equals(metadata, that.metadata) &&
+                Objects.equals(cidrList, that.cidrList) &&
+                Objects.equals(creationTime, that.creationTime) &&
+                Objects.equals(expirationTime, that.expirationTime) &&
+                Objects.equals(lastUpdatedTime, that.lastUpdatedTime) &&
+                Objects.equals(numUses, that.numUses) &&
+                Objects.equals(ttl, that.ttl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, accessor, metadata, cidrList, creationTime, expirationTime, lastUpdatedTime, numUses,
+                ttl);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/Token.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/Token.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -27,9 +28,12 @@ import java.util.*;
  *
  * @author Stefan Kalscheuer
  * @since 0.4.0
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class Token {
+public final class Token implements Serializable {
+    private static final long serialVersionUID = 5208508683665365287L;
+
     /**
      * Get {@link Builder} instance.
      *
@@ -212,6 +216,35 @@ public final class Token {
      */
     public String getEntityAlias() {
         return entityAlias;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Token token = (Token) o;
+        return Objects.equals(id, token.id) &&
+                Objects.equals(type, token.type) &&
+                Objects.equals(displayName, token.displayName) &&
+                Objects.equals(noParent, token.noParent) &&
+                Objects.equals(noDefaultPolicy, token.noDefaultPolicy) &&
+                Objects.equals(ttl, token.ttl) &&
+                Objects.equals(explicitMaxTtl, token.explicitMaxTtl) &&
+                Objects.equals(numUses, token.numUses) &&
+                Objects.equals(policies, token.policies) &&
+                Objects.equals(meta, token.meta) &&
+                Objects.equals(renewable, token.renewable) &&
+                Objects.equals(period, token.period) &&
+                Objects.equals(entityAlias, token.entityAlias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, type, displayName, noParent, noDefaultPolicy, ttl, explicitMaxTtl, numUses, policies,
+                meta, renewable, period, entityAlias);
     }
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
@@ -20,17 +20,22 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Vault Token Role metamodel.
  *
  * @author Stefan Kalscheuer
  * @since 0.9
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class TokenRole {
+public final class TokenRole implements Serializable {
+    private static final long serialVersionUID = -6159563751115867561L;
+
     /**
      * Get {@link Builder} instance.
      *
@@ -203,6 +208,36 @@ public final class TokenRole {
      */
     public String getTokenType() {
         return tokenType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TokenRole tokenRole = (TokenRole) o;
+        return Objects.equals(name, tokenRole.name) &&
+                Objects.equals(allowedPolicies, tokenRole.allowedPolicies) &&
+                Objects.equals(disallowedPolicies, tokenRole.disallowedPolicies) &&
+                Objects.equals(orphan, tokenRole.orphan) &&
+                Objects.equals(renewable, tokenRole.renewable) &&
+                Objects.equals(pathSuffix, tokenRole.pathSuffix) &&
+                Objects.equals(allowedEntityAliases, tokenRole.allowedEntityAliases) &&
+                Objects.equals(tokenBoundCidrs, tokenRole.tokenBoundCidrs) &&
+                Objects.equals(tokenExplicitMaxTtl, tokenRole.tokenExplicitMaxTtl) &&
+                Objects.equals(tokenNoDefaultPolicy, tokenRole.tokenNoDefaultPolicy) &&
+                Objects.equals(tokenNumUses, tokenRole.tokenNumUses) &&
+                Objects.equals(tokenPeriod, tokenRole.tokenPeriod) &&
+                Objects.equals(tokenType, tokenRole.tokenType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, allowedPolicies, disallowedPolicies, orphan, renewable, pathSuffix,
+                allowedEntityAliases, tokenBoundCidrs, tokenExplicitMaxTtl, tokenNoDefaultPolicy, tokenNumUses,
+                tokenPeriod, tokenType);
     }
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleResponse.java
@@ -24,6 +24,7 @@ import de.stklcode.jvault.connector.model.AppRole;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response for AppRole lookup.
@@ -33,6 +34,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AppRoleResponse extends VaultDataResponse {
+    private static final long serialVersionUID = -7817890935652200399L;
+
     private AppRole role;
 
     @Override
@@ -57,5 +60,21 @@ public final class AppRoleResponse extends VaultDataResponse {
      */
     public AppRole getRole() {
         return role;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        AppRoleResponse that = (AppRoleResponse) o;
+        return Objects.equals(role, that.role);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), role);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleResponse.java
@@ -17,13 +17,9 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import de.stklcode.jvault.connector.model.AppRole;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -34,26 +30,10 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AppRoleResponse extends VaultDataResponse {
-    private static final long serialVersionUID = -7817890935652200399L;
+    private static final long serialVersionUID = -6536422219633829177L;
 
+    @JsonProperty("data")
     private AppRole role;
-
-    @Override
-    public void setData(final Map<String, Object> data) throws InvalidResponseException {
-        var mapper = new ObjectMapper();
-        try {
-            /* null empty strings on list objects */
-            Map<String, Object> filteredData = new HashMap<>(data.size(), 1);
-            data.forEach((k, v) -> {
-                if (!(v instanceof String && ((String) v).isEmpty())) {
-                    filteredData.put(k, v);
-                }
-            });
-            this.role = mapper.readValue(mapper.writeValueAsString(filteredData), AppRole.class);
-        } catch (IOException e) {
-            throw new InvalidResponseException("Failed deserializing response", e);
-        }
-    }
 
     /**
      * @return The role

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleSecretResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleSecretResponse.java
@@ -17,13 +17,9 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import de.stklcode.jvault.connector.model.AppRoleSecret;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -34,26 +30,10 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AppRoleSecretResponse extends VaultDataResponse {
-    private static final long serialVersionUID = 7511563325431032667L;
+    private static final long serialVersionUID = -2484103304072370585L;
 
+    @JsonProperty("data")
     private AppRoleSecret secret;
-
-    @Override
-    public void setData(final Map<String, Object> data) throws InvalidResponseException {
-        var mapper = new ObjectMapper();
-        try {
-            /* null empty strings on list objects */
-            Map<String, Object> filteredData = new HashMap<>(data.size(), 1);
-            data.forEach((k, v) -> {
-                if (!(v instanceof String && ((String) v).isEmpty())) {
-                    filteredData.put(k, v);
-                }
-            });
-            this.secret = mapper.readValue(mapper.writeValueAsString(filteredData), AppRoleSecret.class);
-        } catch (IOException e) {
-            throw new InvalidResponseException("Failed deserializing response", e);
-        }
-    }
 
     /**
      * @return The secret

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleSecretResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AppRoleSecretResponse.java
@@ -24,6 +24,7 @@ import de.stklcode.jvault.connector.model.AppRoleSecret;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response for AppRole lookup.
@@ -33,6 +34,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AppRoleSecretResponse extends VaultDataResponse {
+    private static final long serialVersionUID = 7511563325431032667L;
+
     private AppRoleSecret secret;
 
     @Override
@@ -57,5 +60,21 @@ public final class AppRoleSecretResponse extends VaultDataResponse {
      */
     public AppRoleSecret getSecret() {
         return secret;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        AppRoleSecretResponse that = (AppRoleSecretResponse) o;
+        return Objects.equals(secret, that.secret);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), secret);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponse.java
@@ -24,6 +24,7 @@ import de.stklcode.jvault.connector.model.response.embedded.AuthMethod;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Authentication method response.
@@ -33,6 +34,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AuthMethodsResponse extends VaultDataResponse {
+    private static final long serialVersionUID = 5521702564857621352L;
+
     private Map<String, AuthMethod> supportedMethods;
 
     /**
@@ -60,5 +63,21 @@ public final class AuthMethodsResponse extends VaultDataResponse {
      */
     public Map<String, AuthMethod> getSupportedMethods() {
         return supportedMethods;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        AuthMethodsResponse that = (AuthMethodsResponse) o;
+        return Objects.equals(supportedMethods, that.supportedMethods);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), supportedMethods);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponse.java
@@ -17,11 +17,9 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import de.stklcode.jvault.connector.model.response.embedded.AuthMethod;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -34,8 +32,9 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AuthMethodsResponse extends VaultDataResponse {
-    private static final long serialVersionUID = 5521702564857621352L;
+    private static final long serialVersionUID = -1802724129533405375L;
 
+    @JsonProperty("data")
     private Map<String, AuthMethod> supportedMethods;
 
     /**
@@ -43,19 +42,6 @@ public final class AuthMethodsResponse extends VaultDataResponse {
      */
     public AuthMethodsResponse() {
         this.supportedMethods = new HashMap<>();
-    }
-
-    @Override
-    public void setData(final Map<String, Object> data) throws InvalidResponseException {
-        var mapper = new ObjectMapper();
-        for (Map.Entry<String, Object> entry : data.entrySet()) {
-            try {
-                this.supportedMethods.put(entry.getKey(),
-                        mapper.readValue(mapper.writeValueAsString(entry.getValue()), AuthMethod.class));
-            } catch (IOException e) {
-                throw new InvalidResponseException();
-            }
-        }
     }
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AuthResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AuthResponse.java
@@ -18,12 +18,8 @@ package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.AuthData;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -34,39 +30,10 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AuthResponse extends VaultDataResponse {
-    private static final long serialVersionUID = -6728387061352164781L;
+    private static final long serialVersionUID = 1628851361067456715L;
 
-    private Map<String, Object> data;
-
-    private AuthData auth;
-
-    /**
-     * Set authentication data. The input will be mapped to the {@link AuthData} model.
-     *
-     * @param auth Raw authentication data
-     * @throws InvalidResponseException on mapping errors
-     */
     @JsonProperty("auth")
-    public void setAuth(final Map<String, Object> auth) throws InvalidResponseException {
-        var mapper = new ObjectMapper();
-        try {
-            this.auth = mapper.readValue(mapper.writeValueAsString(auth), AuthData.class);
-        } catch (IOException e) {
-            throw new InvalidResponseException("Failed deserializing response", e);
-        }
-    }
-
-    @Override
-    public void setData(final Map<String, Object> data) {
-        this.data = data;
-    }
-
-    /**
-     * @return Raw data
-     */
-    public Map<String, Object> getData() {
-        return data;
-    }
+    private AuthData auth;
 
     /**
      * @return Authentication data
@@ -83,11 +50,11 @@ public final class AuthResponse extends VaultDataResponse {
             return false;
         }
         AuthResponse that = (AuthResponse) o;
-        return Objects.equals(data, that.data) && Objects.equals(auth, that.auth);
+        return Objects.equals(auth, that.auth);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), data, auth);
+        return Objects.hash(super.hashCode(), auth);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AuthResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AuthResponse.java
@@ -24,6 +24,7 @@ import de.stklcode.jvault.connector.model.response.embedded.AuthData;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response for authentication providing auth info in {@link AuthData} field.
@@ -33,6 +34,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AuthResponse extends VaultDataResponse {
+    private static final long serialVersionUID = -6728387061352164781L;
+
     private Map<String, Object> data;
 
     private AuthData auth;
@@ -70,5 +73,21 @@ public final class AuthResponse extends VaultDataResponse {
      */
     public AuthData getAuth() {
         return auth;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        AuthResponse that = (AuthResponse) o;
+        return Objects.equals(data, that.data) && Objects.equals(auth, that.auth);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data, auth);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/CredentialsResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/CredentialsResponse.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class CredentialsResponse extends SecretResponse {
+    private static final long serialVersionUID = -1439692963299045425L;
 
     /**
      * @return Username

--- a/src/main/java/de/stklcode/jvault/connector/model/response/CredentialsResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/CredentialsResponse.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * @since 0.5.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class CredentialsResponse extends SecretResponse {
+public final class CredentialsResponse extends PlainSecretResponse {
     private static final long serialVersionUID = -1439692963299045425L;
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/model/response/ErrorResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/ErrorResponse.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Vault response in case of errors.
@@ -29,6 +30,8 @@ import java.util.List;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class ErrorResponse implements VaultResponse {
+    private static final long serialVersionUID = -6227368087842549149L;
+
     @JsonProperty("errors")
     private List<String> errors;
 
@@ -46,5 +49,21 @@ public final class ErrorResponse implements VaultResponse {
         } else {
             return errors.get(0);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse that = (ErrorResponse) o;
+        return Objects.equals(errors, that.errors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(errors);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/HealthResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/HealthResponse.java
@@ -19,6 +19,8 @@ package de.stklcode.jvault.connector.model.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 /**
  * Vault response for health query.
  *
@@ -27,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class HealthResponse implements VaultResponse {
+    private static final long serialVersionUID = 6483840078694294401L;
+
     @JsonProperty("cluster_id")
     private String clusterID;
 
@@ -128,5 +132,31 @@ public final class HealthResponse implements VaultResponse {
      */
     public Boolean isPerformanceStandby() {
         return performanceStandby;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HealthResponse that = (HealthResponse) o;
+        return Objects.equals(clusterID, that.clusterID) &&
+                Objects.equals(clusterName, that.clusterName) &&
+                Objects.equals(version, that.version) &&
+                Objects.equals(serverTimeUTC, that.serverTimeUTC) &&
+                Objects.equals(standby, that.standby) &&
+                Objects.equals(sealed, that.sealed) &&
+                Objects.equals(initialized, that.initialized) &&
+                Objects.equals(replicationPerfMode, that.replicationPerfMode) &&
+                Objects.equals(replicationDrMode, that.replicationDrMode) &&
+                Objects.equals(performanceStandby, that.performanceStandby);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterID, clusterName, version, serverTimeUTC, standby, sealed, initialized,
+                replicationPerfMode, replicationDrMode, performanceStandby);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/HelpResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/HelpResponse.java
@@ -19,6 +19,8 @@ package de.stklcode.jvault.connector.model.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 /**
  * Vault response for help request.
  *
@@ -27,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class HelpResponse implements VaultResponse {
+    private static final long serialVersionUID = -1152070966642848490L;
+
     @JsonProperty("help")
     private String help;
 
@@ -35,5 +39,21 @@ public final class HelpResponse implements VaultResponse {
      */
     public String getHelp() {
         return help;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HelpResponse that = (HelpResponse) o;
+        return Objects.equals(help, that.help);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(help);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/MetaSecretResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/MetaSecretResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Stefan Kalscheuer
+ * Copyright 2016-2021 Stefan Kalscheuer
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,29 +18,43 @@ package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.stklcode.jvault.connector.model.TokenRole;
-import de.stklcode.jvault.connector.model.response.embedded.TokenData;
+import de.stklcode.jvault.connector.model.response.embedded.SecretWrapper;
+import de.stklcode.jvault.connector.model.response.embedded.VersionMetadata;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 
 /**
- * Vault response from token role lookup providing Token information in {@link TokenData} field.
+ * Vault response for secret responses with metadata.
  *
  * @author Stefan Kalscheuer
- * @since 0.9
+ * @since 1.1 abstract
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class TokenRoleResponse extends VaultDataResponse {
-    private static final long serialVersionUID = 5265363857731948626L;
+public class MetaSecretResponse extends SecretResponse {
+    private static final long serialVersionUID = -1076542846391240162L;
 
     @JsonProperty("data")
-    private TokenRole data;
+    private SecretWrapper secret;
 
-    /**
-     * @return TokenRole data
-     */
-    public TokenRole getData() {
-        return data;
+    @Override
+    public final Map<String, Serializable> getData() {
+        if (secret !=  null) {
+            return secret.getData();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public final VersionMetadata getMetadata() {
+        if (secret !=  null) {
+            return secret.getMetadata();
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -50,12 +64,12 @@ public final class TokenRoleResponse extends VaultDataResponse {
         } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
             return false;
         }
-        TokenRoleResponse that = (TokenRoleResponse) o;
-        return Objects.equals(data, that.data);
+        MetaSecretResponse that = (MetaSecretResponse) o;
+        return Objects.equals(secret, that.secret);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), data);
+        return Objects.hash(super.hashCode(), secret);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/MetadataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/MetadataResponse.java
@@ -23,6 +23,7 @@ import de.stklcode.jvault.connector.model.response.embedded.SecretMetadata;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response for secret metadata (KV v2).
@@ -32,6 +33,7 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataResponse extends VaultDataResponse {
+    private static final long serialVersionUID = 3407081728744500975L;
 
     private SecretMetadata metadata;
 
@@ -52,5 +54,21 @@ public class MetadataResponse extends VaultDataResponse {
      */
     public SecretMetadata getMetadata() {
         return metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        MetadataResponse that = (MetadataResponse) o;
+        return Objects.equals(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), metadata);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/MetadataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/MetadataResponse.java
@@ -17,13 +17,11 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import de.stklcode.jvault.connector.model.response.embedded.SecretMetadata;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
+
 
 /**
  * Vault response for secret metadata (KV v2).
@@ -33,19 +31,10 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataResponse extends VaultDataResponse {
-    private static final long serialVersionUID = 3407081728744500975L;
+    private static final long serialVersionUID = -3679762333630984679L;
 
+    @JsonProperty("data")
     private SecretMetadata metadata;
-
-    @Override
-    public final void setData(final Map<String, Object> data) throws InvalidResponseException {
-        var mapper = new ObjectMapper();
-        try {
-            this.metadata = mapper.readValue(mapper.writeValueAsString(data), SecretMetadata.class);
-        } catch (IOException e) {
-            throw new InvalidResponseException("Failed deserializing response", e);
-        }
-    }
 
     /**
      * Get the actual metadata.

--- a/src/main/java/de/stklcode/jvault/connector/model/response/PlainSecretResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/PlainSecretResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Stefan Kalscheuer
+ * Copyright 2016-2021 Stefan Kalscheuer
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,29 +18,34 @@ package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.stklcode.jvault.connector.model.TokenRole;
-import de.stklcode.jvault.connector.model.response.embedded.TokenData;
+import de.stklcode.jvault.connector.model.response.embedded.VersionMetadata;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 
 /**
- * Vault response from token role lookup providing Token information in {@link TokenData} field.
+ * Vault response for plain secret responses.
  *
  * @author Stefan Kalscheuer
- * @since 0.9
+ * @since 1.1 abstract
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class TokenRoleResponse extends VaultDataResponse {
-    private static final long serialVersionUID = 5265363857731948626L;
+public class PlainSecretResponse extends SecretResponse {
+    private static final long serialVersionUID = 3010138542437913023L;
 
     @JsonProperty("data")
-    private TokenRole data;
+    private Map<String, Serializable> data;
 
-    /**
-     * @return TokenRole data
-     */
-    public TokenRole getData() {
-        return data;
+    @Override
+    public final Map<String, Serializable> getData() {
+        return Objects.requireNonNullElseGet(data, Collections::emptyMap);
+    }
+
+    @Override
+    public final VersionMetadata getMetadata() {
+        return null;
     }
 
     @Override
@@ -50,7 +55,7 @@ public final class TokenRoleResponse extends VaultDataResponse {
         } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
             return false;
         }
-        TokenRoleResponse that = (TokenRoleResponse) o;
+        PlainSecretResponse that = (PlainSecretResponse) o;
         return Objects.equals(data, that.data);
     }
 

--- a/src/main/java/de/stklcode/jvault/connector/model/response/RawDataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/RawDataResponse.java
@@ -17,7 +17,9 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 
@@ -29,19 +31,15 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class RawDataResponse extends VaultDataResponse {
-    private static final long serialVersionUID = -5494734676257709074L;
+    private static final long serialVersionUID = -319727427792124071L;
 
-    private Map<String, Object> data;
-
-    @Override
-    public void setData(final Map<String, Object> data) {
-        this.data = data;
-    }
+    @JsonProperty("data")
+    private Map<String, Serializable> data;
 
     /**
      * @return Raw data {@link Map}
      */
-    public Map<String, Object> getData() {
+    public Map<String, Serializable> getData() {
         return data;
     }
 

--- a/src/main/java/de/stklcode/jvault/connector/model/response/RawDataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/RawDataResponse.java
@@ -19,6 +19,7 @@ package de.stklcode.jvault.connector.model.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Simple Vault data response.
@@ -28,6 +29,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class RawDataResponse extends VaultDataResponse {
+    private static final long serialVersionUID = -5494734676257709074L;
+
     private Map<String, Object> data;
 
     @Override
@@ -40,5 +43,21 @@ public final class RawDataResponse extends VaultDataResponse {
      */
     public Map<String, Object> getData() {
         return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        RawDataResponse that = (RawDataResponse) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SealResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SealResponse.java
@@ -19,6 +19,8 @@ package de.stklcode.jvault.connector.model.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 /**
  * Vault response for seal status or unseal request.
  *
@@ -27,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SealResponse implements VaultResponse {
+    private static final long serialVersionUID = -3661916639367542617L;
+
     @JsonProperty("type")
     private String type;
 
@@ -164,5 +168,34 @@ public final class SealResponse implements VaultResponse {
      */
     public String getStorageType() {
         return storageType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SealResponse that = (SealResponse) o;
+        return sealed == that.sealed &&
+                initialized == that.initialized &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(threshold, that.threshold) &&
+                Objects.equals(numberOfShares, that.numberOfShares) &&
+                Objects.equals(progress, that.progress) &&
+                Objects.equals(version, that.version) &&
+                Objects.equals(nonce, that.nonce) &&
+                Objects.equals(clusterName, that.clusterName) &&
+                Objects.equals(clusterId, that.clusterId) &&
+                Objects.equals(migration, that.migration) &&
+                Objects.equals(recoverySeal, that.recoverySeal) &&
+                Objects.equals(storageType, that.storageType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, sealed, initialized, threshold, numberOfShares, progress, version, nonce,
+                clusterName, clusterId, migration, recoverySeal, storageType);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SecretListResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SecretListResponse.java
@@ -22,6 +22,7 @@ import de.stklcode.jvault.connector.exception.InvalidResponseException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response for secret list request.
@@ -31,13 +32,14 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SecretListResponse extends VaultDataResponse {
+    private static final long serialVersionUID = -5279146643326713976L;
+
     private List<String> keys;
 
     /**
      * Set data. Extracts list of keys from raw response data.
      *
      * @param data Raw data
-     * @throws InvalidResponseException on parsing errors
      */
     @JsonProperty("data")
     public void setData(final Map<String, Object> data) throws InvalidResponseException {
@@ -53,5 +55,21 @@ public final class SecretListResponse extends VaultDataResponse {
      */
     public List<String> getKeys() {
         return keys;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        SecretListResponse that = (SecretListResponse) o;
+        return Objects.equals(keys, that.keys);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), keys);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SecretListResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SecretListResponse.java
@@ -18,10 +18,10 @@ package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import de.stklcode.jvault.connector.model.response.embedded.SecretListWrapper;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -32,29 +32,19 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SecretListResponse extends VaultDataResponse {
-    private static final long serialVersionUID = -5279146643326713976L;
 
-    private List<String> keys;
-
-    /**
-     * Set data. Extracts list of keys from raw response data.
-     *
-     * @param data Raw data
-     */
+    private static final long serialVersionUID = 8597121175002967213L;
     @JsonProperty("data")
-    public void setData(final Map<String, Object> data) throws InvalidResponseException {
-        try {
-            this.keys = (List<String>) data.get("keys");
-        } catch (ClassCastException e) {
-            throw new InvalidResponseException("Keys could not be parsed from data.", e);
-        }
-    }
+    private SecretListWrapper data;
 
     /**
      * @return List of secret keys
      */
     public List<String> getKeys() {
-        return keys;
+        if (data == null) {
+            return Collections.emptyList();
+        }
+        return Objects.requireNonNullElseGet(data.getKeys(), Collections::emptyList);
     }
 
     @Override
@@ -65,11 +55,11 @@ public final class SecretListResponse extends VaultDataResponse {
             return false;
         }
         SecretListResponse that = (SecretListResponse) o;
-        return Objects.equals(keys, that.keys);
+        return Objects.equals(data, that.data);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), keys);
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SecretResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SecretResponse.java
@@ -24,6 +24,7 @@ import de.stklcode.jvault.connector.model.response.embedded.VersionMetadata;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response for secret request.
@@ -33,6 +34,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SecretResponse extends VaultDataResponse {
+    private static final long serialVersionUID = -8215178956885015265L;
+
     private static final String KEY_DATA = "data";
     private static final String KEY_METADATA = "metadata";
 
@@ -115,5 +118,21 @@ public class SecretResponse extends VaultDataResponse {
         } catch (IOException e) {
             throw new InvalidResponseException("Unable to parse response payload: " + e.getMessage());
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        SecretResponse that = (SecretResponse) o;
+        return Objects.equals(data, that.data) && Objects.equals(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data, metadata);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SecretVersionResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SecretVersionResponse.java
@@ -23,6 +23,7 @@ import de.stklcode.jvault.connector.model.response.embedded.VersionMetadata;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response for a single secret version metadata, i.e. after update (KV v2).
@@ -32,6 +33,7 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SecretVersionResponse extends VaultDataResponse {
+    private static final long serialVersionUID = -6681638207727120184L;
 
     private VersionMetadata metadata;
 
@@ -52,5 +54,21 @@ public class SecretVersionResponse extends VaultDataResponse {
      */
     public VersionMetadata getMetadata() {
         return metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        SecretVersionResponse that = (SecretVersionResponse) o;
+        return Objects.equals(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), metadata);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SecretVersionResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SecretVersionResponse.java
@@ -17,12 +17,9 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import de.stklcode.jvault.connector.model.response.embedded.VersionMetadata;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -33,19 +30,10 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SecretVersionResponse extends VaultDataResponse {
-    private static final long serialVersionUID = -6681638207727120184L;
+    private static final long serialVersionUID = 2748635005258576174L;
 
+    @JsonProperty("data")
     private VersionMetadata metadata;
-
-    @Override
-    public final void setData(final Map<String, Object> data) throws InvalidResponseException {
-        var mapper = new ObjectMapper();
-        try {
-            this.metadata = mapper.readValue(mapper.writeValueAsString(data), VersionMetadata.class);
-        } catch (IOException e) {
-            throw new InvalidResponseException("Failed deserializing response", e);
-        }
-    }
 
     /**
      * Get the actual metadata.

--- a/src/main/java/de/stklcode/jvault/connector/model/response/TokenResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/TokenResponse.java
@@ -24,6 +24,7 @@ import de.stklcode.jvault.connector.model.response.embedded.TokenData;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response from token lookup providing Token information in {@link TokenData} field.
@@ -33,6 +34,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TokenResponse extends VaultDataResponse {
+    private static final long serialVersionUID = 2248288114849229479L;
+
     private TokenData data;
 
     @JsonProperty("auth")
@@ -59,5 +62,21 @@ public final class TokenResponse extends VaultDataResponse {
      */
     public TokenData getData() {
         return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        TokenResponse that = (TokenResponse) o;
+        return Objects.equals(data, that.data) && Objects.equals(auth, that.auth);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data, auth);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/TokenResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/TokenResponse.java
@@ -18,12 +18,8 @@ package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.TokenData;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -34,34 +30,26 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TokenResponse extends VaultDataResponse {
-    private static final long serialVersionUID = 2248288114849229479L;
+    private static final long serialVersionUID = -4053126653764241197L;
 
+    @JsonProperty("data")
     private TokenData data;
 
     @JsonProperty("auth")
     private Boolean auth;
 
     /**
-     * Set data. Parses response data map to {@link TokenData}.
-     *
-     * @param data Raw response data
-     * @throws InvalidResponseException on parsing errors
-     */
-    @Override
-    public void setData(final Map<String, Object> data) throws InvalidResponseException {
-        var mapper = new ObjectMapper();
-        try {
-            this.data = mapper.readValue(mapper.writeValueAsString(data), TokenData.class);
-        } catch (IOException e) {
-            throw new InvalidResponseException("Failed deserializing response", e);
-        }
-    }
-
-    /**
      * @return Token data
      */
     public TokenData getData() {
         return data;
+    }
+
+    /**
+     * @return Auth data
+     */
+    public Boolean getAuth() {
+        return auth;
     }
 
     @Override

--- a/src/main/java/de/stklcode/jvault/connector/model/response/TokenRoleResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/TokenRoleResponse.java
@@ -24,6 +24,7 @@ import de.stklcode.jvault.connector.model.response.embedded.TokenData;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Vault response from token role lookup providing Token information in {@link TokenData} field.
@@ -33,6 +34,8 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TokenRoleResponse extends VaultDataResponse {
+    private static final long serialVersionUID = -6622498881812517596L;
+
     private TokenRole data;
 
     /**
@@ -56,5 +59,21 @@ public final class TokenRoleResponse extends VaultDataResponse {
      */
     public TokenRole getData() {
         return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
+            return false;
+        }
+        TokenRoleResponse that = (TokenRoleResponse) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
@@ -17,11 +17,9 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.WrapInfo;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -47,15 +45,6 @@ public abstract class VaultDataResponse implements VaultResponse {
 
     @JsonProperty("wrap_info")
     private WrapInfo wrapInfo;
-
-    /**
-     * Set data. To be implemented in the specific subclasses, as data can be of arbitrary structure.
-     *
-     * @param data Raw response data
-     * @throws InvalidResponseException on parsing errors
-     */
-    @JsonProperty("data")
-    public abstract void setData(final Map<String, Object> data) throws InvalidResponseException;
 
     /**
      * @return Lease ID

--- a/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
@@ -22,6 +22,7 @@ import de.stklcode.jvault.connector.model.response.embedded.WrapInfo;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Abstract Vault response with default payload fields.
@@ -30,6 +31,8 @@ import java.util.Map;
  * @since 0.1
  */
 public abstract class VaultDataResponse implements VaultResponse {
+    private static final long serialVersionUID = 2507925101227179499L;
+
     @JsonProperty("lease_id")
     private String leaseId;
 
@@ -88,5 +91,25 @@ public abstract class VaultDataResponse implements VaultResponse {
      */
     public final WrapInfo getWrapInfo() {
         return wrapInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VaultDataResponse that = (VaultDataResponse) o;
+        return renewable == that.renewable &&
+                Objects.equals(leaseId, that.leaseId) &&
+                Objects.equals(leaseDuration, that.leaseDuration) &&
+                Objects.equals(warnings, that.warnings) &&
+                Objects.equals(wrapInfo, that.wrapInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(leaseId, renewable, leaseDuration, warnings, wrapInfo);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/VaultResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/VaultResponse.java
@@ -16,11 +16,14 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import java.io.Serializable;
+
 /**
  * Marker interface for responses from Vault backend.
  *
  * @author Stefan Kalscheuer
  * @since 0.1
+ * @since 1.1 extends {@link Serializable}
  */
-public interface VaultResponse {
+public interface VaultResponse extends Serializable {
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
@@ -19,17 +19,22 @@ package de.stklcode.jvault.connector.model.response.embedded;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Embedded authorization information inside Vault response.
  *
  * @author Stefan Kalscheuer
  * @since 0.1
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class AuthData {
+public final class AuthData implements Serializable {
+    private static final long serialVersionUID = -6962244199229885869L;
+
     @JsonProperty("client_token")
     private String clientToken;
 
@@ -132,5 +137,32 @@ public final class AuthData {
      */
     public boolean isOrphan() {
         return orphan;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AuthData authData = (AuthData) o;
+        return renewable == authData.renewable &&
+                orphan == authData.orphan &&
+                Objects.equals(clientToken, authData.clientToken) &&
+                Objects.equals(accessor, authData.accessor) &&
+                Objects.equals(policies, authData.policies) &&
+                Objects.equals(tokenPolicies, authData.tokenPolicies) &&
+                Objects.equals(metadata, authData.metadata) &&
+                Objects.equals(leaseDuration, authData.leaseDuration) &&
+                Objects.equals(entityId, authData.entityId) &&
+                Objects.equals(tokenType, authData.tokenType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clientToken, accessor, policies, tokenPolicies, metadata, leaseDuration, renewable,
+                entityId, tokenType, orphan);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthMethod.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthMethod.java
@@ -21,16 +21,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import de.stklcode.jvault.connector.model.AuthBackend;
 
+import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Embedded authentication method response.
  *
  * @author Stefan Kalscheuer
  * @since 0.1
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class AuthMethod {
+public final class AuthMethod implements Serializable {
+    private static final long serialVersionUID = -5241997986380823391L;
+
     private AuthBackend type;
     private String rawType;
 
@@ -85,5 +90,25 @@ public final class AuthMethod {
      */
     public boolean isLocal() {
         return local;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AuthMethod that = (AuthMethod) o;
+        return local == that.local &&
+                type == that.type &&
+                Objects.equals(rawType, that.rawType) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, rawType, description, config, local);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretListWrapper.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretListWrapper.java
@@ -1,0 +1,42 @@
+package de.stklcode.jvault.connector.model.response.embedded;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Wrapper object for secret key lists.
+ *
+ * @author Stefan Kalscheuer
+ * @since 1.1
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SecretListWrapper implements Serializable {
+
+    private static final long serialVersionUID = -8777605197063766125L;
+    @JsonProperty("keys")
+    private List<String> keys;
+
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SecretListWrapper that = (SecretListWrapper) o;
+        return Objects.equals(keys, that.keys);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keys);
+    }
+}

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretMetadata.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretMetadata.java
@@ -19,19 +19,24 @@ package de.stklcode.jvault.connector.model.response.embedded;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Embedded metadata for Key-Value v2 secrets.
  *
  * @author Stefan Kalscheuer
  * @since 0.8
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class SecretMetadata {
+public final class SecretMetadata implements Serializable {
+    private static final long serialVersionUID = 1684891108903409038L;
+
     private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSX");
 
     @JsonProperty("created_time")
@@ -124,4 +129,24 @@ public final class SecretMetadata {
         return versions;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SecretMetadata that = (SecretMetadata) o;
+        return Objects.equals(createdTimeString, that.createdTimeString) &&
+                Objects.equals(currentVersion, that.currentVersion) &&
+                Objects.equals(maxVersions, that.maxVersions) &&
+                Objects.equals(oldestVersion, that.oldestVersion) &&
+                Objects.equals(updatedTime, that.updatedTime) &&
+                Objects.equals(versions, that.versions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(createdTimeString, currentVersion, maxVersions, oldestVersion, updatedTime, versions);
+    }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretWrapper.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretWrapper.java
@@ -1,0 +1,49 @@
+package de.stklcode.jvault.connector.model.response.embedded;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Wrapper object for secret data and metadata.
+ *
+ * @author Stefan Kalscheuer
+ * @since 1.1
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SecretWrapper implements Serializable {
+    private static final long serialVersionUID = 8600413181758893378L;
+
+    @JsonProperty("data")
+    private Map<String, Serializable> data;
+
+    @JsonProperty("metadata")
+    private VersionMetadata metadata;
+
+    public Map<String, Serializable> getData() {
+        return data;
+    }
+
+    public VersionMetadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SecretWrapper that = (SecretWrapper) o;
+        return Objects.equals(data, that.data) && Objects.equals(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, metadata);
+    }
+}

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
@@ -19,18 +19,23 @@ package de.stklcode.jvault.connector.model.response.embedded;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Embedded token information inside Vault response.
  *
  * @author Stefan Kalscheuer
  * @since 0.1
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class TokenData {
+public final class TokenData implements Serializable {
+    private static final long serialVersionUID = 2915180734313753649L;
+
     @JsonProperty("accessor")
     private String accessor;
 
@@ -230,5 +235,38 @@ public final class TokenData {
      */
     public Map<String, Object> getMeta() {
         return meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TokenData tokenData = (TokenData) o;
+        return orphan == tokenData.orphan &&
+                renewable == tokenData.renewable &&
+                Objects.equals(accessor, tokenData.accessor) &&
+                Objects.equals(creationTime, tokenData.creationTime) &&
+                Objects.equals(creationTtl, tokenData.creationTtl) &&
+                Objects.equals(name, tokenData.name) &&
+                Objects.equals(entityId, tokenData.entityId) &&
+                Objects.equals(expireTime, tokenData.expireTime) &&
+                Objects.equals(explicitMaxTtl, tokenData.explicitMaxTtl) &&
+                Objects.equals(id, tokenData.id) &&
+                Objects.equals(issueTime, tokenData.issueTime) &&
+                Objects.equals(meta, tokenData.meta) &&
+                Objects.equals(numUses, tokenData.numUses) &&
+                Objects.equals(path, tokenData.path) &&
+                Objects.equals(policies, tokenData.policies) &&
+                Objects.equals(ttl, tokenData.ttl) &&
+                Objects.equals(type, tokenData.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accessor, creationTime, creationTtl, name, entityId, expireTime, explicitMaxTtl, id,
+                issueTime, meta, numUses, orphan, path, policies, renewable, ttl, type);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/VersionMetadata.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/VersionMetadata.java
@@ -19,18 +19,23 @@ package de.stklcode.jvault.connector.model.response.embedded;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Objects;
 
 /**
  * Embedded metadata for a single Key-Value v2 version.
  *
  * @author Stefan Kalscheuer
  * @since 0.8
+ * @since 1.1 implements {@link Serializable}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class VersionMetadata {
+public final class VersionMetadata implements Serializable {
+    private static final long serialVersionUID = -5286693953873839611L;
+
     private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSX");
 
     @JsonProperty("created_time")
@@ -103,4 +108,22 @@ public final class VersionMetadata {
         return version;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VersionMetadata that = (VersionMetadata) o;
+        return destroyed == that.destroyed &&
+                Objects.equals(createdTimeString, that.createdTimeString) &&
+                Objects.equals(deletionTimeString, that.deletionTimeString) &&
+                Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(createdTimeString, deletionTimeString, destroyed, version);
+    }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/WrapInfo.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/WrapInfo.java
@@ -18,13 +18,17 @@ package de.stklcode.jvault.connector.model.response.embedded;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+import java.util.Objects;
+
 /**
  * Wrapping information object.
  *
  * @author Stefan Kalscheuer
  * @since 1.1
  */
-public class WrapInfo {
+public class WrapInfo implements Serializable {
+    private static final long serialVersionUID = -7764500642913116581L;
 
     @JsonProperty("token")
     private String token;
@@ -64,5 +68,24 @@ public class WrapInfo {
      */
     public String getCreationPath() {
         return creationPath;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WrapInfo that = (WrapInfo) o;
+        return Objects.equals(token, that.token) &&
+                Objects.equals(ttl, that.ttl) &&
+                Objects.equals(creationTime, that.creationTime) &&
+                Objects.equals(creationPath, that.creationPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token, ttl, creationTime, creationPath);
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/AbstractModelTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AbstractModelTest.java
@@ -1,0 +1,70 @@
+package de.stklcode.jvault.connector.model;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Abstract testcase for model classes.
+ *
+ * @author Stefan Kalscheuer
+ * @since 1.1
+ */
+public abstract class AbstractModelTest<T> {
+    protected final Class<?> modelClass;
+
+    /**
+     * Test case constructor.
+     *
+     * @param modelClass Target class to test.
+     */
+    protected AbstractModelTest(Class<T> modelClass) {
+        this.modelClass = modelClass;
+    }
+
+    /**
+     * Create a "full" model instance.
+     *
+     * @return Model instance.
+     */
+    protected abstract T createFull();
+
+    /**
+     * Test if {@link Object#equals(Object)} and {@link Object#hashCode()} are implemented, s.t. all fields are covered.
+     */
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(modelClass).verify();
+    }
+
+    /**
+     * Test Java serialization of a full model instance.
+     * Serialization and deserialization must not fail and the resulting object should equal the original object.
+     */
+    @Test
+    void serializationTest() {
+        T original = createFull();
+        byte[] bytes;
+        try (var bos = new ByteArrayOutputStream();
+             var oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(original);
+            bytes = bos.toByteArray();
+        } catch (IOException e) {
+            fail("Serialization failed", e);
+            return;
+        }
+
+        try (var bis = new ByteArrayInputStream(bytes);
+             var ois = new ObjectInputStream(bis)) {
+            Object copy = ois.readObject();
+            assertEquals(modelClass, copy.getClass(), "Invalid class after deserialization");
+            assertEquals(original, copy, "Deserialized object should be equal to the original");
+        } catch (IOException | ClassNotFoundException e) {
+            fail("Deserialization failed", e);
+        }
+    }
+}

--- a/src/test/java/de/stklcode/jvault/connector/model/AppRoleSecretTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AppRoleSecretTest.java
@@ -17,11 +17,10 @@
 package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -37,13 +36,11 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  */
 class AppRoleSecretTest {
     private static final String TEST_ID = "abc123";
-    private static final Map<String, Object> TEST_META = new HashMap<>();
-    private static final List<String> TEST_CIDR = Arrays.asList("203.0.113.0/24", "198.51.100.0/24");
-
-    static {
-        TEST_META.put("foo", "bar");
-        TEST_META.put("number", 1337);
-    }
+    private static final Map<String, Object> TEST_META = Map.of(
+            "foo", "bar",
+            "number", 1337
+    );
+    private static final List<String> TEST_CIDR = List.of("203.0.113.0/24", "198.51.100.0/24");
 
     /**
      * Test constructors.
@@ -167,7 +164,11 @@ class AppRoleSecretTest {
         assertEquals("TEST_LASTUPDATE", secret2.getLastUpdatedTime());
         assertEquals(678, secret2.getNumUses());
         assertEquals(12345, secret2.getTtl());
+    }
 
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(AppRoleSecret.class).verify();
     }
 
     private static void setPrivateField(Object object, String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {
@@ -182,5 +183,4 @@ class AppRoleSecretTest {
         return json.replaceAll("\"cidr_list\":\"([^\"]*)\"", "\"cidr_list\":\\[$1\\]")
                 .replaceAll("(\\d+\\.\\d+\\.\\d+\\.\\d+/\\d+)", "\"$1\"");
     }
-
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/AppRoleSecretTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AppRoleSecretTest.java
@@ -17,7 +17,6 @@
 package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -34,13 +33,22 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * @author Stefan Kalscheuer
  * @since 0.5.0
  */
-class AppRoleSecretTest {
+class AppRoleSecretTest extends AbstractModelTest<AppRoleSecret> {
     private static final String TEST_ID = "abc123";
     private static final Map<String, Object> TEST_META = Map.of(
             "foo", "bar",
             "number", 1337
     );
     private static final List<String> TEST_CIDR = List.of("203.0.113.0/24", "198.51.100.0/24");
+
+    AppRoleSecretTest() {
+        super(AppRoleSecret.class);
+    }
+
+    @Override
+    protected AppRoleSecret createFull() {
+        return new AppRoleSecret(TEST_ID, TEST_META, TEST_CIDR);
+    }
 
     /**
      * Test constructors.
@@ -164,11 +172,6 @@ class AppRoleSecretTest {
         assertEquals("TEST_LASTUPDATE", secret2.getLastUpdatedTime());
         assertEquals(678, secret2.getNumUses());
         assertEquals(12345, secret2.getTtl());
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(AppRoleSecret.class).verify();
     }
 
     private static void setPrivateField(Object object, String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {

--- a/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
@@ -18,7 +18,6 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.4.0
  */
-class AppRoleTest {
+class AppRoleTest extends AbstractModelTest<AppRole> {
     private static final String NAME = "TestRole";
     private static final String ID = "test-id";
     private static final Boolean BIND_SECRET_ID = true;
@@ -56,6 +55,31 @@ class AppRoleTest {
     private static final String JSON_MIN = "{\"role_name\":\"" + NAME + "\"}";
     private static final String JSON_FULL = String.format("{\"role_name\":\"%s\",\"role_id\":\"%s\",\"bind_secret_id\":%s,\"secret_id_bound_cidrs\":\"%s\",\"secret_id_num_uses\":%d,\"secret_id_ttl\":%d,\"enable_local_secret_ids\":%s,\"token_ttl\":%d,\"token_max_ttl\":%d,\"token_policies\":\"%s\",\"token_bound_cidrs\":\"%s\",\"token_explicit_max_ttl\":%d,\"token_no_default_policy\":%s,\"token_num_uses\":%d,\"token_period\":%d,\"token_type\":\"%s\"}",
             NAME, ID, BIND_SECRET_ID, CIDR_1, SECRET_ID_NUM_USES, SECRET_ID_TTL, ENABLE_LOCAL_SECRET_IDS, TOKEN_TTL, TOKEN_MAX_TTL, POLICY, CIDR_1, TOKEN_EXPLICIT_MAX_TTL, TOKEN_NO_DEFAULT_POLICY, TOKEN_NUM_USES, TOKEN_PERIOD, TOKEN_TYPE.value());
+
+    AppRoleTest() {
+        super(AppRole.class);
+    }
+
+    @Override
+    protected AppRole createFull() {
+        return AppRole.builder(NAME)
+                .withId(ID)
+                .withBindSecretID(BIND_SECRET_ID)
+                .withSecretIdBoundCidrs(BOUND_CIDR_LIST)
+                .withTokenPolicies(POLICIES)
+                .withSecretIdNumUses(SECRET_ID_NUM_USES)
+                .withSecretIdTtl(SECRET_ID_TTL)
+                .withEnableLocalSecretIds(ENABLE_LOCAL_SECRET_IDS)
+                .withTokenTtl(TOKEN_TTL)
+                .withTokenMaxTtl(TOKEN_MAX_TTL)
+                .withTokenBoundCidrs(BOUND_CIDR_LIST)
+                .withTokenExplicitMaxTtl(TOKEN_EXPLICIT_MAX_TTL)
+                .withTokenNoDefaultPolicy(TOKEN_NO_DEFAULT_POLICY)
+                .withTokenNumUses(TOKEN_NUM_USES)
+                .withTokenPeriod(TOKEN_PERIOD)
+                .withTokenType(TOKEN_TYPE)
+                .build();
+    }
 
     @BeforeAll
     static void init() {
@@ -94,23 +118,7 @@ class AppRoleTest {
      */
     @Test
     void buildFullTest() throws JsonProcessingException {
-        AppRole role = AppRole.builder(NAME)
-                .withId(ID)
-                .withBindSecretID(BIND_SECRET_ID)
-                .withSecretIdBoundCidrs(BOUND_CIDR_LIST)
-                .withTokenPolicies(POLICIES)
-                .withSecretIdNumUses(SECRET_ID_NUM_USES)
-                .withSecretIdTtl(SECRET_ID_TTL)
-                .withEnableLocalSecretIds(ENABLE_LOCAL_SECRET_IDS)
-                .withTokenTtl(TOKEN_TTL)
-                .withTokenMaxTtl(TOKEN_MAX_TTL)
-                .withTokenBoundCidrs(BOUND_CIDR_LIST)
-                .withTokenExplicitMaxTtl(TOKEN_EXPLICIT_MAX_TTL)
-                .withTokenNoDefaultPolicy(TOKEN_NO_DEFAULT_POLICY)
-                .withTokenNumUses(TOKEN_NUM_USES)
-                .withTokenPeriod(TOKEN_PERIOD)
-                .withTokenType(TOKEN_TYPE)
-                .build();
+        AppRole role = createFull();
         assertEquals(NAME, role.getName());
         assertEquals(ID, role.getId());
         assertEquals(BIND_SECRET_ID, role.getBindSecretId());
@@ -172,10 +180,5 @@ class AppRoleTest {
                 .build();
         assertEquals(2, role.getTokenPolicies().size());
         assertTrue(role.getTokenPolicies().containsAll(List.of(POLICY, POLICY_2)));
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(AppRole.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
@@ -18,6 +18,7 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -171,5 +172,10 @@ class AppRoleTest {
                 .build();
         assertEquals(2, role.getTokenPolicies().size());
         assertTrue(role.getTokenPolicies().containsAll(List.of(POLICY, POLICY_2)));
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(AppRole.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenRoleTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenRoleTest.java
@@ -18,6 +18,7 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -26,12 +27,12 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit Test for {@link Token.Builder}
+ * Unit Test for {@link TokenRole} and {@link TokenRole.Builder}.
  *
  * @author Stefan Kalscheuer
  * @since 0.9
  */
-class TokenRoleBuilderTest {
+class TokenRoleTest {
     private static final String NAME = "test-role";
     private static final String ALLOWED_POLICY_1 = "apol-1";
     private static final String ALLOWED_POLICY_2 = "apol-2";
@@ -132,6 +133,9 @@ class TokenRoleBuilderTest {
         assertNull(role.getTokenPeriod());
         assertNull(role.getTokenType());
 
+        // Empty builder should be equal to no-arg construction.
+        assertEquals(role, new TokenRole());
+
         // Optional fields should be ignored, so JSON string should be empty.
         assertEquals("{}", new ObjectMapper().writeValueAsString(role));
     }
@@ -179,5 +183,10 @@ class TokenRoleBuilderTest {
 
         // Verify that all parameters are included in JSON string.
         assertEquals(JSON_FULL, new ObjectMapper().writeValueAsString(role));
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(TokenRole.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenRoleTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenRoleTest.java
@@ -18,7 +18,6 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -32,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.9
  */
-class TokenRoleTest {
+class TokenRoleTest extends AbstractModelTest<TokenRole> {
     private static final String NAME = "test-role";
     private static final String ALLOWED_POLICY_1 = "apol-1";
     private static final String ALLOWED_POLICY_2 = "apol-2";
@@ -73,6 +72,33 @@ class TokenRoleTest {
             "\"token_num_uses\":" + TOKEN_NUM_USES + "," +
             "\"token_period\":" + TOKEN_PERIOD + "," +
             "\"token_type\":\"" + TOKEN_TYPE.value() + "\"}";
+
+    TokenRoleTest() {
+        super(TokenRole.class);
+    }
+
+    @Override
+    protected TokenRole createFull() {
+        return TokenRole.builder()
+                .forName(NAME)
+                .withAllowedPolicies(ALLOWED_POLICIES)
+                .withAllowedPolicy(ALLOWED_POLICY_3)
+                .withDisallowedPolicy(DISALLOWED_POLICY_1)
+                .withDisallowedPolicies(DISALLOWED_POLICIES)
+                .orphan(ORPHAN)
+                .renewable(RENEWABLE)
+                .withPathSuffix(PATH_SUFFIX)
+                .withAllowedEntityAliases(ALLOWED_ENTITY_ALIASES)
+                .withAllowedEntityAlias(ALLOWED_ENTITY_ALIAS_2)
+                .withTokenBoundCidr(TOKEN_BOUND_CIDR_3)
+                .withTokenBoundCidrs(TOKEN_BOUND_CIDRS)
+                .withTokenExplicitMaxTtl(TOKEN_EXPLICIT_MAX_TTL)
+                .withTokenNoDefaultPolicy(TOKEN_NO_DEFAULT_POLICY)
+                .withTokenNumUses(TOKEN_NUM_USES)
+                .withTokenPeriod(TOKEN_PERIOD)
+                .withTokenType(TOKEN_TYPE)
+                .build();
+    }
 
     /**
      * Build token without any parameters.
@@ -145,25 +171,7 @@ class TokenRoleTest {
      */
     @Test
     void buildFullTest() throws JsonProcessingException {
-        TokenRole role = TokenRole.builder()
-                .forName(NAME)
-                .withAllowedPolicies(ALLOWED_POLICIES)
-                .withAllowedPolicy(ALLOWED_POLICY_3)
-                .withDisallowedPolicy(DISALLOWED_POLICY_1)
-                .withDisallowedPolicies(DISALLOWED_POLICIES)
-                .orphan(ORPHAN)
-                .renewable(RENEWABLE)
-                .withPathSuffix(PATH_SUFFIX)
-                .withAllowedEntityAliases(ALLOWED_ENTITY_ALIASES)
-                .withAllowedEntityAlias(ALLOWED_ENTITY_ALIAS_2)
-                .withTokenBoundCidr(TOKEN_BOUND_CIDR_3)
-                .withTokenBoundCidrs(TOKEN_BOUND_CIDRS)
-                .withTokenExplicitMaxTtl(TOKEN_EXPLICIT_MAX_TTL)
-                .withTokenNoDefaultPolicy(TOKEN_NO_DEFAULT_POLICY)
-                .withTokenNumUses(TOKEN_NUM_USES)
-                .withTokenPeriod(TOKEN_PERIOD)
-                .withTokenType(TOKEN_TYPE)
-                .build();
+        TokenRole role = createFull();
         assertEquals(NAME, role.getName());
         assertEquals(ALLOWED_POLICIES.size() + 1, role.getAllowedPolicies().size());
         assertTrue(role.getAllowedPolicies().containsAll(List.of(ALLOWED_POLICY_1, ALLOWED_POLICY_2, ALLOWED_POLICY_3)));
@@ -183,10 +191,5 @@ class TokenRoleTest {
 
         // Verify that all parameters are included in JSON string.
         assertEquals(JSON_FULL, new ObjectMapper().writeValueAsString(role));
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(TokenRole.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenTest.java
@@ -18,6 +18,7 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -81,6 +82,9 @@ class TokenTest {
 
         // Optional fields should be ignored, so JSON string should be empty.
         assertEquals("{}", new ObjectMapper().writeValueAsString(token));
+
+        // Empty builder should be equal to no-arg construction.
+        assertEquals(token, new Token());
     }
 
     /**
@@ -166,5 +170,10 @@ class TokenTest {
         assertEquals(2, token.getMeta().size());
         assertEquals(META_VALUE, token.getMeta().get(META_KEY));
         assertEquals(META_VALUE_2, token.getMeta().get(META_KEY_2));
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(Token.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenTest.java
@@ -18,7 +18,6 @@ package de.stklcode.jvault.connector.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.4.0
  */
-class TokenTest {
+class TokenTest extends AbstractModelTest<Token> {
     private static final String ID = "test-id";
     private static final String DISPLAY_NAME = "display-name";
     private static final Boolean NO_PARENT = false;
@@ -53,6 +52,29 @@ class TokenTest {
     private static final Integer PERIOD = 3600;
     private static final String ENTITY_ALIAS = "alias-value";
     private static final String JSON_FULL = "{\"id\":\"test-id\",\"type\":\"service\",\"display_name\":\"display-name\",\"no_parent\":false,\"no_default_policy\":false,\"ttl\":123,\"explicit_max_ttl\":456,\"num_uses\":4,\"policies\":[\"policy\"],\"meta\":{\"key\":\"value\"},\"renewable\":true,\"period\":3600,\"entity_alias\":\"alias-value\"}";
+
+    TokenTest() {
+        super(Token.class);
+    }
+
+    @Override
+    protected Token createFull() {
+        return Token.builder()
+                .withId(ID)
+                .withType(Token.Type.SERVICE)
+                .withDisplayName(DISPLAY_NAME)
+                .withNoParent(NO_PARENT)
+                .withNoDefaultPolicy(NO_DEFAULT_POLICY)
+                .withTtl(TTL)
+                .withExplicitMaxTtl(EXPLICIT_MAX_TTL)
+                .withNumUses(NUM_USES)
+                .withPolicies(POLICIES)
+                .withMeta(META)
+                .withRenewable(RENEWABLE)
+                .withPeriod(PERIOD)
+                .withEntityAlias(ENTITY_ALIAS)
+                .build();
+    }
 
     @BeforeAll
     static void init() {
@@ -92,21 +114,7 @@ class TokenTest {
      */
     @Test
     void buildFullTest() throws JsonProcessingException {
-        Token token = Token.builder()
-                .withId(ID)
-                .withType(Token.Type.SERVICE)
-                .withDisplayName(DISPLAY_NAME)
-                .withNoParent(NO_PARENT)
-                .withNoDefaultPolicy(NO_DEFAULT_POLICY)
-                .withTtl(TTL)
-                .withExplicitMaxTtl(EXPLICIT_MAX_TTL)
-                .withNumUses(NUM_USES)
-                .withPolicies(POLICIES)
-                .withMeta(META)
-                .withRenewable(RENEWABLE)
-                .withPeriod(PERIOD)
-                .withEntityAlias(ENTITY_ALIAS)
-                .build();
+        Token token = createFull();
         assertEquals(ID, token.getId());
         assertEquals(Token.Type.SERVICE.value(), token.getType());
         assertEquals(DISPLAY_NAME, token.getDisplayName());
@@ -170,10 +178,5 @@ class TokenTest {
         assertEquals(2, token.getMeta().size());
         assertEquals(META_VALUE, token.getMeta().get(META_KEY));
         assertEquals(META_VALUE_2, token.getMeta().get(META_KEY_2));
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(Token.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
@@ -17,13 +17,11 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.AppRole;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -63,8 +61,6 @@ class AppRoleResponseTest {
             "  \"lease_id\": \"\"\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_DATA = Map.of("token_policies", "fancy-policy");
-
     /**
      * Test getter, setter and get-methods for response data.
      */
@@ -73,13 +69,6 @@ class AppRoleResponseTest {
         // Create empty Object.
         AppRoleResponse res = new AppRoleResponse();
         assertNull(res.getRole(), "Initial data should be empty");
-
-        // Parsing invalid auth data map should fail.
-        assertThrows(
-                InvalidResponseException.class,
-                () -> res.setData(INVALID_DATA),
-                "Parsing invalid data succeeded"
-        );
     }
 
     /**

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
@@ -16,9 +16,10 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import de.stklcode.jvault.connector.model.AppRole;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.6.2
  */
-class AppRoleResponseTest {
+class AppRoleResponseTest extends AbstractModelTest<AppRoleResponse> {
     private static final Integer ROLE_TOKEN_TTL = 1200;
     private static final Integer ROLE_TOKEN_MAX_TTL = 1800;
     private static final Integer ROLE_SECRET_TTL = 600;
@@ -60,6 +61,20 @@ class AppRoleResponseTest {
             "  \"renewable\": false,\n" +
             "  \"lease_id\": \"\"\n" +
             "}";
+
+    AppRoleResponseTest() {
+        super(AppRoleResponse.class);
+    }
+
+    @Override
+    protected AppRoleResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(RES_JSON, AppRoleResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -93,10 +108,5 @@ class AppRoleResponseTest {
         assertEquals(ROLE_BIND_SECRET, role.getBindSecretId(), "Incorrect role bind secret ID flag");
         assertNull(role.getTokenBoundCidrs(), "Incorrect bound CIDR list");
         assertEquals("", role.getTokenBoundCidrsString(), "Incorrect bound CIDR list string");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(AppRoleResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
@@ -19,9 +19,9 @@ package de.stklcode.jvault.connector.model.response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.AppRole;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,11 +63,7 @@ class AppRoleResponseTest {
             "  \"lease_id\": \"\"\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_DATA = new HashMap<>();
-
-    static {
-        INVALID_DATA.put("token_policies", "fancy-policy");
-    }
+    private static final Map<String, Object> INVALID_DATA = Map.of("token_policies", "fancy-policy");
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -108,5 +104,10 @@ class AppRoleResponseTest {
         assertEquals(ROLE_BIND_SECRET, role.getBindSecretId(), "Incorrect role bind secret ID flag");
         assertNull(role.getTokenBoundCidrs(), "Incorrect bound CIDR list");
         assertEquals("", role.getTokenBoundCidrsString(), "Incorrect bound CIDR list string");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(AppRoleResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
@@ -16,14 +16,13 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import de.stklcode.jvault.connector.model.AuthBackend;
 import de.stklcode.jvault.connector.model.response.embedded.AuthMethod;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.6.2
  */
-class AuthMethodsResponseTest {
+class AuthMethodsResponseTest extends AbstractModelTest<AuthMethodsResponse> {
     private static final String GH_PATH = "github/";
     private static final String GH_TYPE = "github";
     private static final String GH_DESCR = "GitHub auth";
@@ -62,6 +61,20 @@ class AuthMethodsResponseTest {
             "    }\n" +
             "  }\n" +
             "}";
+
+    AuthMethodsResponseTest() {
+        super(AuthMethodsResponse.class);
+    }
+
+    @Override
+    protected AuthMethodsResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(RES_JSON, AuthMethodsResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -105,14 +118,5 @@ class AuthMethodsResponseTest {
         assertEquals(2, method.getConfig().size(), "Unexpected config size for Token");
         assertEquals(TK_LEASE_TTL.toString(), method.getConfig().get("default_lease_ttl"), "Incorrect lease TTL config");
         assertEquals(TK_MAX_LEASE_TTL.toString(), method.getConfig().get("max_lease_ttl"), "Incorrect max lease TTL config");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(AuthMethodsResponse.class).verify();
-    }
-
-    private static class Dummy implements Serializable {
-        private static final long serialVersionUID = 9075949348402246139L;
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
@@ -20,10 +20,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.AuthBackend;
 import de.stklcode.jvault.connector.model.response.embedded.AuthMethod;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -62,11 +63,7 @@ class AuthMethodsResponseTest {
             "  }\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_DATA = new HashMap<>();
-
-    static {
-        INVALID_DATA.put("dummy/", new Dummy());
-    }
+    private static final Map<String, Object> INVALID_DATA = Map.of("dummy/", new Dummy());
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -119,7 +116,12 @@ class AuthMethodsResponseTest {
         assertEquals(TK_MAX_LEASE_TTL.toString(), method.getConfig().get("max_lease_ttl"), "Incorrect max lease TTL config");
     }
 
-    private static class Dummy {
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(AuthMethodsResponse.class).verify();
+    }
 
+    private static class Dummy implements Serializable {
+        private static final long serialVersionUID = 9075949348402246139L;
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
@@ -63,8 +63,6 @@ class AuthMethodsResponseTest {
             "  }\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_DATA = Map.of("dummy/", new Dummy());
-
     /**
      * Test getter, setter and get-methods for response data.
      */
@@ -73,13 +71,6 @@ class AuthMethodsResponseTest {
         // Create empty Object.
         AuthMethodsResponse res = new AuthMethodsResponse();
         assertEquals(Collections.emptyMap(), res.getSupportedMethods(), "Initial method map should be empty");
-
-        // Parsing invalid data map should fail.
-        assertThrows(
-                InvalidResponseException.class,
-                () -> res.setData(INVALID_DATA),
-                "Parsing invalid data succeeded"
-        );
     }
 
     /**

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
@@ -19,9 +19,9 @@ package de.stklcode.jvault.connector.model.response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.AuthData;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -69,11 +69,7 @@ class AuthResponseTest {
             "  }\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_AUTH_DATA = new HashMap<>();
-
-    static {
-        INVALID_AUTH_DATA.put("policies", "fancy-policy");
-    }
+    private static final Map<String, Object> INVALID_AUTH_DATA = Map.of("policies", "fancy-policy");
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -121,5 +117,10 @@ class AuthResponseTest {
         assertEquals(2, data.getTokenPolicies().size(), "Incorrect number of token policies");
         assertTrue(data.getTokenPolicies().containsAll(Set.of(AUTH_POLICY_2, AUTH_POLICY_1)), "Incorrect token policies");
         assertEquals(Map.of(AUTH_META_KEY, AUTH_META_VALUE), data.getMetadata(), "Incorrect auth metadata");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(AuthResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
@@ -17,7 +17,6 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.AuthData;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
@@ -69,8 +68,6 @@ class AuthResponseTest {
             "  }\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_AUTH_DATA = Map.of("policies", "fancy-policy");
-
     /**
      * Test getter, setter and get-methods for response data.
      */
@@ -78,18 +75,8 @@ class AuthResponseTest {
     void getDataRoundtrip() {
         // Create empty Object.
         AuthResponse res = new AuthResponse();
-        assertNull(res.getData(), "Initial data should be empty");
-
-        // Parsing invalid auth data map should fail.
-        assertThrows(
-                InvalidResponseException.class,
-                () -> res.setAuth(INVALID_AUTH_DATA),
-                "Parsing invalid auth data succeeded"
-        );
-
-        // Data method should be agnostic.
-        res.setData(INVALID_AUTH_DATA);
-        assertEquals(INVALID_AUTH_DATA, res.getData(), "Data not passed through");
+        // TODO
+//        assertNull(res.getData(), "Initial data should be empty");
     }
 
     /**

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
@@ -16,9 +16,10 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import de.stklcode.jvault.connector.model.response.embedded.AuthData;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -32,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.6.2
  */
-class AuthResponseTest {
+class AuthResponseTest extends AbstractModelTest<AuthResponse> {
     private static final String AUTH_ACCESSOR = "2c84f488-2133-4ced-87b0-570f93a76830";
     private static final String AUTH_CLIENT_TOKEN = "ABCD";
     private static final String AUTH_POLICY_1 = "web";
@@ -68,15 +69,18 @@ class AuthResponseTest {
             "  }\n" +
             "}";
 
-    /**
-     * Test getter, setter and get-methods for response data.
-     */
-    @Test
-    void getDataRoundtrip() {
-        // Create empty Object.
-        AuthResponse res = new AuthResponse();
-        // TODO
-//        assertNull(res.getData(), "Initial data should be empty");
+    AuthResponseTest() {
+        super(AuthResponse.class);
+    }
+
+    @Override
+    protected AuthResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(RES_JSON, AuthResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
     }
 
     /**
@@ -104,10 +108,5 @@ class AuthResponseTest {
         assertEquals(2, data.getTokenPolicies().size(), "Incorrect number of token policies");
         assertTrue(data.getTokenPolicies().containsAll(Set.of(AUTH_POLICY_2, AUTH_POLICY_1)), "Incorrect token policies");
         assertEquals(Map.of(AUTH_META_KEY, AUTH_META_VALUE), data.getMetadata(), "Incorrect auth metadata");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(AuthResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/CredentialsResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/CredentialsResponseTest.java
@@ -17,9 +17,9 @@
 package de.stklcode.jvault.connector.model.response;
 
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,14 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * @since 0.8
  */
 class CredentialsResponseTest {
-    private static final Map<String, Object> DATA = new HashMap<>();
     private static final String VAL_USER = "testUserName";
     private static final String VAL_PASS = "5up3r5ecr3tP455";
-
-    static {
-        DATA.put("username", VAL_USER);
-        DATA.put("password", VAL_PASS);
-    }
+    private static final Map<String, Object> DATA = Map.of(
+            "username", VAL_USER,
+            "password", VAL_PASS
+    );
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -47,7 +45,6 @@ class CredentialsResponseTest {
      * @throws InvalidResponseException Should not occur
      */
     @Test
-    @SuppressWarnings("unchecked")
     void getCredentialsTest() throws InvalidResponseException {
         // Create empty Object.
         CredentialsResponse res = new CredentialsResponse();
@@ -58,5 +55,10 @@ class CredentialsResponseTest {
         res.setData(DATA);
         assertEquals(VAL_USER, res.getUsername(), "Incorrect username");
         assertEquals(VAL_PASS, res.getPassword(), "Incorrect password");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(CredentialsResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/CredentialsResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/CredentialsResponseTest.java
@@ -16,14 +16,12 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * JUnit Test for {@link CredentialsResponse} model.
@@ -34,10 +32,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class CredentialsResponseTest {
     private static final String VAL_USER = "testUserName";
     private static final String VAL_PASS = "5up3r5ecr3tP455";
-    private static final Map<String, Object> DATA = Map.of(
-            "username", VAL_USER,
-            "password", VAL_PASS
-    );
+    private static final String JSON = "{\n" +
+            "    \"request_id\": \"68315073-6658-e3ff-2da7-67939fb91bbd\",\n" +
+            "    \"lease_id\": \"\",\n" +
+            "    \"lease_duration\": 2764800,\n" +
+            "    \"renewable\": false,\n" +
+            "    \"data\": {\n" +
+            "        \"username\": \"" + VAL_USER + "\",\n" +
+            "        \"password\": \"" + VAL_PASS + "\"\n" +
+            "    },\n" +
+            "    \"warnings\": null\n" +
+            "}";
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -51,8 +56,10 @@ class CredentialsResponseTest {
         assertNull(res.getUsername(), "Username not present in data map should not return anything");
         assertNull(res.getPassword(), "Password not present in data map should not return anything");
 
-        // Fill data map.
-        res.setData(DATA);
+        res = assertDoesNotThrow(
+                () -> new ObjectMapper().readValue(JSON, CredentialsResponse.class),
+                "Deserialization of CredentialsResponse failed"
+        );
         assertEquals(VAL_USER, res.getUsername(), "Incorrect username");
         assertEquals(VAL_PASS, res.getPassword(), "Incorrect password");
     }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/CredentialsResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/CredentialsResponseTest.java
@@ -16,9 +16,10 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.8
  */
-class CredentialsResponseTest {
+class CredentialsResponseTest extends AbstractModelTest<CredentialsResponse> {
     private static final String VAL_USER = "testUserName";
     private static final String VAL_PASS = "5up3r5ecr3tP455";
     private static final String JSON = "{\n" +
@@ -43,6 +44,20 @@ class CredentialsResponseTest {
             "    },\n" +
             "    \"warnings\": null\n" +
             "}";
+
+    CredentialsResponseTest() {
+        super(CredentialsResponse.class);
+    }
+
+    @Override
+    protected CredentialsResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(JSON, CredentialsResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -62,10 +77,5 @@ class CredentialsResponseTest {
         );
         assertEquals(VAL_USER, res.getUsername(), "Incorrect username");
         assertEquals(VAL_PASS, res.getPassword(), "Incorrect password");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(CredentialsResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/ErrorResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/ErrorResponseTest.java
@@ -16,8 +16,9 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,12 +30,26 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Stefan Kalscheuer
  */
-class ErrorResponseTest {
+class ErrorResponseTest extends AbstractModelTest<ErrorResponse> {
     private static final String ERROR_1 = "Error #1";
     private static final String ERROR_2 = "Error #2";
 
     private static final String JSON = "{\"errors\":[\"" + ERROR_1 + "\",\"" + ERROR_2 + "\"]}";
     private static final String JSON_EMPTY = "{\"errors\":[]}";
+
+    ErrorResponseTest() {
+        super(ErrorResponse.class);
+    }
+
+    @Override
+    protected ErrorResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(JSON, ErrorResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
 
     /**
      * Test creation from JSON value as returned by Vault.
@@ -71,10 +86,5 @@ class ErrorResponseTest {
         assertEquals("error response", res.toString());
 
         assertEquals("error response", new ErrorResponse().toString());
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(ErrorResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/ErrorResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/ErrorResponseTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2021 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JUnit Test for {@link ErrorResponse} model.
+ *
+ * @author Stefan Kalscheuer
+ */
+class ErrorResponseTest {
+    private static final String ERROR_1 = "Error #1";
+    private static final String ERROR_2 = "Error #2";
+
+    private static final String JSON = "{\"errors\":[\"" + ERROR_1 + "\",\"" + ERROR_2 + "\"]}";
+    private static final String JSON_EMPTY = "{\"errors\":[]}";
+
+    /**
+     * Test creation from JSON value as returned by Vault.
+     */
+    @Test
+    void jsonRoundtrip() {
+        ObjectMapper om = new ObjectMapper();
+        ErrorResponse res = assertDoesNotThrow(
+                () -> om.readValue(JSON, ErrorResponse.class),
+                "ErrorResponse deserialization failed"
+        );
+        assertNotNull(res, "Parsed response is NULL");
+        assertEquals(List.of(ERROR_1, ERROR_2), res.getErrors(), "Unexpected error messages");
+        assertEquals(
+                JSON,
+                assertDoesNotThrow(() -> om.writeValueAsString(res), "ErrorResponse serialization failed"),
+                "Unexpected JSON string after serialization"
+        );
+    }
+
+
+    @Test
+    void testToString() {
+        ErrorResponse res = assertDoesNotThrow(
+                () -> new ObjectMapper().readValue(JSON, ErrorResponse.class),
+                "ErrorResponse deserialization failed"
+        );
+        assertEquals(ERROR_1, res.toString());
+
+        res = assertDoesNotThrow(
+                () -> new ObjectMapper().readValue(JSON_EMPTY, ErrorResponse.class),
+                "ErrorResponse deserialization failed with empty list"
+        );
+        assertEquals("error response", res.toString());
+
+        assertEquals("error response", new ErrorResponse().toString());
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(ErrorResponse.class).verify();
+    }
+}

--- a/src/test/java/de/stklcode/jvault/connector/model/response/HealthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/HealthResponseTest.java
@@ -16,8 +16,9 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.7.0
  */
-class HealthResponseTest {
+class HealthResponseTest extends AbstractModelTest<HealthResponse> {
     private static final String CLUSTER_ID = "c9abceea-4f46-4dab-a688-5ce55f89e228";
     private static final String CLUSTER_NAME = "vault-cluster-5515c810";
     private static final String VERSION = "0.9.2";
@@ -53,6 +54,20 @@ class HealthResponseTest {
             "  \"performance_standby\": " + PERF_STANDBY + "\n" +
             "}";
 
+    HealthResponseTest() {
+        super(HealthResponse.class);
+    }
+
+    @Override
+    protected HealthResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(RES_JSON, HealthResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
+
     /**
      * Test creation from JSON value as returned by Vault (JSON example copied from Vault documentation).
      */
@@ -73,10 +88,5 @@ class HealthResponseTest {
         assertEquals(PERF_STANDBY, res.isPerformanceStandby(), "Incorrect performance standby state");
         assertEquals(REPL_PERF_MODE, res.getReplicationPerfMode(), "Incorrect replication perf mode");
         assertEquals(REPL_DR_MODE, res.getReplicationDrMode(), "Incorrect replication DR mode");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(HealthResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/HealthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/HealthResponseTest.java
@@ -17,6 +17,7 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -72,5 +73,10 @@ class HealthResponseTest {
         assertEquals(PERF_STANDBY, res.isPerformanceStandby(), "Incorrect performance standby state");
         assertEquals(REPL_PERF_MODE, res.getReplicationPerfMode(), "Incorrect replication perf mode");
         assertEquals(REPL_DR_MODE, res.getReplicationDrMode(), "Incorrect replication DR mode");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(HealthResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/HelpResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/HelpResponseTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2021 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JUnit Test for {@link HelpResponse} model.
+ *
+ * @author Stefan Kalscheuer
+ */
+class HelpResponseTest {
+    private static final String HELP = "Help Text.";
+
+    private static final String JSON = "{\"help\":\"" + HELP + "\"}";
+
+    /**
+     * Test creation from JSON value as returned by Vault.
+     */
+    @Test
+    void jsonRoundtrip() {
+        ObjectMapper om = new ObjectMapper();
+        HelpResponse res = assertDoesNotThrow(
+                () -> om.readValue(JSON, HelpResponse.class),
+                "HelpResponse deserialization failed"
+        );
+        assertNotNull(res, "Parsed response is NULL");
+        assertEquals(HELP, res.getHelp(), "Unexpected help text");
+        assertEquals(
+                JSON,
+                assertDoesNotThrow(() -> om.writeValueAsString(res), "HelpResponse serialization failed"),
+                "Unexpected JSON string after serialization"
+        );
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(HelpResponse.class).verify();
+    }
+}

--- a/src/test/java/de/stklcode/jvault/connector/model/response/HelpResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/HelpResponseTest.java
@@ -16,8 +16,9 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -27,10 +28,24 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Stefan Kalscheuer
  */
-class HelpResponseTest {
+class HelpResponseTest extends AbstractModelTest<HelpResponse> {
     private static final String HELP = "Help Text.";
 
     private static final String JSON = "{\"help\":\"" + HELP + "\"}";
+
+    HelpResponseTest() {
+        super(HelpResponse.class);
+    }
+
+    @Override
+    protected HelpResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(JSON, HelpResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
 
     /**
      * Test creation from JSON value as returned by Vault.
@@ -49,10 +64,5 @@ class HelpResponseTest {
                 assertDoesNotThrow(() -> om.writeValueAsString(res), "HelpResponse serialization failed"),
                 "Unexpected JSON string after serialization"
         );
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(HelpResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/MetaSecretResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/MetaSecretResponseTest.java
@@ -16,8 +16,9 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -25,12 +26,12 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * JUnit Test for {@link SecretResponse} model.
+ * JUnit Test for {@link MetaSecretResponse} model.
  *
  * @author Stefan Kalscheuer
  * @since 0.6.2
  */
-class SecretResponseTest {
+class MetaSecretResponseTest extends AbstractModelTest<MetaSecretResponse> {
     private static final String SECRET_REQUEST_ID = "68315073-6658-e3ff-2da7-67939fb91bbd";
     private static final String SECRET_LEASE_ID = "";
     private static final Integer SECRET_LEASE_DURATION = 2764800;
@@ -42,17 +43,6 @@ class SecretResponseTest {
     private static final String SECRET_META_CREATED = "2018-03-22T02:24:06.945319214Z";
     private static final String SECRET_META_DELETED = "2018-03-23T03:25:07.056420325Z";
     private static final List<String> SECRET_WARNINGS = null;
-    private static final String SECRET_JSON = "{\n" +
-            "    \"request_id\": \"" + SECRET_REQUEST_ID + "\",\n" +
-            "    \"lease_id\": \"" + SECRET_LEASE_ID + "\",\n" +
-            "    \"lease_duration\": " + SECRET_LEASE_DURATION + ",\n" +
-            "    \"renewable\": " + SECRET_RENEWABLE + ",\n" +
-            "    \"data\": {\n" +
-            "        \"" + SECRET_DATA_K1 + "\": \"" + SECRET_DATA_V1 + "\",\n" +
-            "        \"" + SECRET_DATA_K2 + "\": \"" + SECRET_DATA_V2 + "\"\n" +
-            "    },\n" +
-            "    \"warnings\": " + SECRET_WARNINGS + "\n" +
-            "}";
     private static final String SECRET_JSON_V2 = "{\n" +
             "    \"request_id\": \"" + SECRET_REQUEST_ID + "\",\n" +
             "    \"lease_id\": \"" + SECRET_LEASE_ID + "\",\n" +
@@ -92,19 +82,27 @@ class SecretResponseTest {
             "    \"warnings\": " + SECRET_WARNINGS + "\n" +
             "}";
 
+    MetaSecretResponseTest() {
+        super(MetaSecretResponse.class);
+    }
+
+    @Override
+    protected MetaSecretResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(SECRET_JSON_V2, MetaSecretResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
+
     /**
      * Test creation from JSON value as returned by Vault (JSON example copied from Vault documentation).
      */
     @Test
     void jsonRoundtrip() {
-        SecretResponse res = assertDoesNotThrow(
-                () -> new ObjectMapper().readValue(SECRET_JSON, PlainSecretResponse.class),
-                "SecretResponse deserialization failed"
-        );
-        assertSecretData(res);
-
         // KV v2 secret.
-        res = assertDoesNotThrow(
+        MetaSecretResponse res = assertDoesNotThrow(
                 () -> new ObjectMapper().readValue(SECRET_JSON_V2, MetaSecretResponse.class),
                 "SecretResponse deserialization failed"
         );
@@ -130,13 +128,6 @@ class SecretResponseTest {
         assertNotNull(res.getMetadata().getDeletionTime(), "Incorrect deletion date");
         assertTrue(res.getMetadata().isDestroyed(), "Secret destroyed when not expected");
         assertEquals(2, res.getMetadata().getVersion(), "Incorrect secret version");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(SecretResponse.class).verify();
-        EqualsVerifier.simple().forClass(PlainSecretResponse.class).verify();
-        EqualsVerifier.simple().forClass(MetaSecretResponse.class).verify();
     }
 
     private void assertSecretData(SecretResponse res) {

--- a/src/test/java/de/stklcode/jvault/connector/model/response/MetadataResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/MetadataResponseTest.java
@@ -17,6 +17,7 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -87,5 +88,10 @@ class MetadataResponseTest {
         assertEquals(V2_TIME, res.getMetadata().getVersions().get(2).getCreatedTimeString(), "Incorrect version 2 created time");
         assertNotNull(res.getMetadata().getVersions().get(2).getCreatedTime(), "Parsing version created failed");
         assertFalse(res.getMetadata().getVersions().get(3).isDestroyed(), "Incorrect version 3 destroyed state");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(MetadataResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/MetadataResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/MetadataResponseTest.java
@@ -16,8 +16,9 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.8
  */
-class MetadataResponseTest {
+class MetadataResponseTest extends AbstractModelTest<MetadataResponse> {
     private static final String V1_TIME = "2018-03-22T02:24:06.945319214Z";
     private static final String V3_TIME = "2018-03-22T02:36:43.986212308Z";
     private static final String V2_TIME = "2018-03-22T02:36:33.954880664Z";
@@ -63,6 +64,20 @@ class MetadataResponseTest {
             "  }\n" +
             "}";
 
+    MetadataResponseTest() {
+        super(MetadataResponse.class);
+    }
+
+    @Override
+    protected MetadataResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(META_JSON, MetadataResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
+
     /**
      * Test creation from JSON value as returned by Vault (JSON example copied from Vault documentation).
      */
@@ -88,10 +103,5 @@ class MetadataResponseTest {
         assertEquals(V2_TIME, res.getMetadata().getVersions().get(2).getCreatedTimeString(), "Incorrect version 2 created time");
         assertNotNull(res.getMetadata().getVersions().get(2).getCreatedTime(), "Parsing version created failed");
         assertFalse(res.getMetadata().getVersions().get(3).isDestroyed(), "Incorrect version 3 destroyed state");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(MetadataResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/PlainSecretResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/PlainSecretResponseTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016-2021 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model.response;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JUnit Test for {@link PlainSecretResponse} model.
+ *
+ * @author Stefan Kalscheuer
+ * @since 0.6.2
+ */
+class PlainSecretResponseTest extends AbstractModelTest<PlainSecretResponse> {
+    private static final String SECRET_REQUEST_ID = "68315073-6658-e3ff-2da7-67939fb91bbd";
+    private static final String SECRET_LEASE_ID = "";
+    private static final Integer SECRET_LEASE_DURATION = 2764800;
+    private static final boolean SECRET_RENEWABLE = false;
+    private static final String SECRET_DATA_K1 = "excited";
+    private static final String SECRET_DATA_V1 = "yes";
+    private static final String SECRET_DATA_K2 = "value";
+    private static final String SECRET_DATA_V2 = "world";
+    private static final List<String> SECRET_WARNINGS = null;
+    private static final String SECRET_JSON = "{\n" +
+            "    \"request_id\": \"" + SECRET_REQUEST_ID + "\",\n" +
+            "    \"lease_id\": \"" + SECRET_LEASE_ID + "\",\n" +
+            "    \"lease_duration\": " + SECRET_LEASE_DURATION + ",\n" +
+            "    \"renewable\": " + SECRET_RENEWABLE + ",\n" +
+            "    \"data\": {\n" +
+            "        \"" + SECRET_DATA_K1 + "\": \"" + SECRET_DATA_V1 + "\",\n" +
+            "        \"" + SECRET_DATA_K2 + "\": \"" + SECRET_DATA_V2 + "\"\n" +
+            "    },\n" +
+            "    \"warnings\": " + SECRET_WARNINGS + "\n" +
+            "}";
+
+    PlainSecretResponseTest() {
+        super(PlainSecretResponse.class);
+    }
+
+    @Override
+    protected PlainSecretResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(SECRET_JSON, PlainSecretResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
+
+    /**
+     * Test creation from JSON value as returned by Vault (JSON example copied from Vault documentation).
+     */
+    @Test
+    void jsonRoundtrip() {
+        SecretResponse res = assertDoesNotThrow(
+                () -> new ObjectMapper().readValue(SECRET_JSON, PlainSecretResponse.class),
+                "SecretResponse deserialization failed"
+        );
+
+        assertNotNull(res, "Parsed response is NULL");
+        assertEquals(SECRET_LEASE_ID, res.getLeaseId(), "Incorrect lease ID");
+        assertEquals(SECRET_LEASE_DURATION, res.getLeaseDuration(), "Incorrect lease duration");
+        assertEquals(SECRET_RENEWABLE, res.isRenewable(), "Incorrect renewable status");
+        assertEquals(SECRET_WARNINGS, res.getWarnings(), "Incorrect warnings");
+        assertEquals(SECRET_DATA_V1, res.get(SECRET_DATA_K1), "Response does not contain correct data");
+        assertEquals(SECRET_DATA_V2, res.get(SECRET_DATA_K2), "Response does not contain correct data");
+    }
+}

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SealResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SealResponseTest.java
@@ -17,6 +17,7 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -79,7 +80,7 @@ class SealResponseTest {
         // First test sealed Vault's response.
         SealResponse res = assertDoesNotThrow(
                 () -> new ObjectMapper().readValue(RES_SEALED, SealResponse.class),
-                "TokenResponse deserialization failed"
+                "SealResponse deserialization failed"
         );
         assertNotNull(res, "Parsed response is NULL");
         assertEquals(TYPE, res.getType(), "Incorrect seal type");
@@ -101,7 +102,7 @@ class SealResponseTest {
         // Not test unsealed Vault's response.
         res = assertDoesNotThrow(
                 () -> new ObjectMapper().readValue(RES_UNSEALED, SealResponse.class),
-                "TokenResponse deserialization failed"
+                "SealResponse deserialization failed"
         );
         assertNotNull(res, "Parsed response is NULL");
         assertEquals(TYPE, res.getType(), "Incorrect seal type");
@@ -117,5 +118,10 @@ class SealResponseTest {
         assertEquals(MIGRATION, res.getMigration(), "Incorrect migration");
         assertEquals(RECOVERY_SEAL, res.getRecoverySeal(), "Incorrect recovery seal");
         assertEquals(STORAGE_TYPE, res.getStorageType(), "Incorrect storage type");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(SealResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SealResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SealResponseTest.java
@@ -16,8 +16,9 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.8
  */
-class SealResponseTest {
+class SealResponseTest extends AbstractModelTest<SealResponse> {
     private static final String TYPE = "shamir";
     private static final Integer THRESHOLD = 3;
     private static final Integer SHARES = 5;
@@ -71,6 +72,20 @@ class SealResponseTest {
             "  \"recovery_seal\": \"" + RECOVERY_SEAL + "\",\n" +
             "  \"storage_type\": \"" + STORAGE_TYPE + "\"\n" +
             "}";
+
+    SealResponseTest() {
+        super(SealResponse.class);
+    }
+
+    @Override
+    protected SealResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(RES_UNSEALED, SealResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
 
     /**
      * Test creation from JSON value as returned by Vault when sealed (JSON example close to Vault documentation).
@@ -118,10 +133,5 @@ class SealResponseTest {
         assertEquals(MIGRATION, res.getMigration(), "Incorrect migration");
         assertEquals(RECOVERY_SEAL, res.getRecoverySeal(), "Incorrect recovery seal");
         assertEquals(STORAGE_TYPE, res.getStorageType(), "Incorrect storage type");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(SealResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SecretListResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SecretListResponseTest.java
@@ -16,16 +16,14 @@
 
 package de.stklcode.jvault.connector.model.response;
 
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit Test for {@link SecretListResponse} model.
@@ -36,33 +34,30 @@ import static org.junit.jupiter.api.Assertions.*;
 class SecretListResponseTest {
     private static final String KEY1 = "key1";
     private static final String KEY2 = "key-2";
-    private static final List<String> KEYS = Arrays.asList(KEY1, KEY2);
-    private static final Map<String, Object> DATA = Map.of("keys", KEYS);
+    private static final String JSON = "{\n" +
+            "  \"auth\": null,\n" +
+            "  \"data\": {\n" +
+            "    \"keys\": [" +
+            "      \"" + KEY1 + "\",\n" +
+            "      \"" + KEY2 + "\"\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"lease_duration\": 2764800,\n" +
+            "  \"lease_id\": \"\",\n" +
+            "  \"renewable\": false\n" +
+            "}";
 
     /**
-     * Test getter, setter and get-methods for response data.
-     *
-     * @throws InvalidResponseException Should not occur
+     * Test JSON deserialization and key getter.
      */
     @Test
-    void getKeysTest() throws InvalidResponseException {
-        // Create empty Object.
-        SecretListResponse res = new SecretListResponse();
-        assertNull(res.getKeys(), "Keys should be null without initialization");
-
-        // Provoke internal ClassCastException.
-        Map<String, Object> invalidData = Map.of("keys", "some string");
-        assertThrows(
-                InvalidResponseException.class,
-                () -> res.setData(invalidData),
-                "Setting incorrect class succeeded"
+    void getKeysTest() {
+        SecretListResponse res = assertDoesNotThrow(
+                () -> new ObjectMapper().readValue(JSON, SecretListResponse.class),
+                "SecretListResponse deserialization failed"
         );
 
-        // Fill correct data.
-        res.setData(DATA);
-        assertNotNull(res.getKeys(), "Keys should be filled here");
-        assertEquals(2, res.getKeys().size(), "Unexpected number of keys");
-        assertTrue(res.getKeys().containsAll(Set.of(KEY1, KEY2)), "Unexpected keys");
+        assertEquals(List.of(KEY1, KEY2), res.getKeys(), "Unexpected secret keys");
     }
 
     @Test

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SecretListResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SecretListResponseTest.java
@@ -16,14 +16,14 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * JUnit Test for {@link SecretListResponse} model.
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Stefan Kalscheuer
  * @since 0.8
  */
-class SecretListResponseTest {
+class SecretListResponseTest extends AbstractModelTest<SecretListResponse> {
     private static final String KEY1 = "key1";
     private static final String KEY2 = "key-2";
     private static final String JSON = "{\n" +
@@ -47,6 +47,20 @@ class SecretListResponseTest {
             "  \"renewable\": false\n" +
             "}";
 
+    SecretListResponseTest() {
+        super(SecretListResponse.class);
+    }
+
+    @Override
+    protected SecretListResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(JSON, SecretListResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
+
     /**
      * Test JSON deserialization and key getter.
      */
@@ -58,10 +72,5 @@ class SecretListResponseTest {
         );
 
         assertEquals(List.of(KEY1, KEY2), res.getKeys(), "Unexpected secret keys");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(SecretListResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SecretListResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SecretListResponseTest.java
@@ -17,9 +17,13 @@
 package de.stklcode.jvault.connector.model.response;
 
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,14 +34,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 0.8
  */
 class SecretListResponseTest {
-    private static final Map<String, Object> DATA = new HashMap<>();
     private static final String KEY1 = "key1";
     private static final String KEY2 = "key-2";
     private static final List<String> KEYS = Arrays.asList(KEY1, KEY2);
-
-    static {
-        DATA.put("keys", KEYS);
-    }
+    private static final Map<String, Object> DATA = Map.of("keys", KEYS);
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -51,8 +51,7 @@ class SecretListResponseTest {
         assertNull(res.getKeys(), "Keys should be null without initialization");
 
         // Provoke internal ClassCastException.
-        Map<String, Object> invalidData = new HashMap<>();
-        invalidData.put("keys", "some string");
+        Map<String, Object> invalidData = Map.of("keys", "some string");
         assertThrows(
                 InvalidResponseException.class,
                 () -> res.setData(invalidData),
@@ -64,5 +63,10 @@ class SecretListResponseTest {
         assertNotNull(res.getKeys(), "Keys should be filled here");
         assertEquals(2, res.getKeys().size(), "Unexpected number of keys");
         assertTrue(res.getKeys().containsAll(Set.of(KEY1, KEY2)), "Unexpected keys");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(SecretListResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SecretResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SecretResponseTest.java
@@ -18,9 +18,9 @@ package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 0.6.2
  */
 class SecretResponseTest {
-    private static final Map<String, Object> DATA = new HashMap<>();
     private static final String KEY_UNKNOWN = "unknown";
     private static final String KEY_STRING = "test1";
     private static final String VAL_STRING = "testvalue";
@@ -42,6 +41,12 @@ class SecretResponseTest {
     private static final Integer VAL_INTEGER = 42;
     private static final String KEY_LIST = "list";
     private static final String VAL_LIST = "[\"first\",\"second\"]";
+
+    private static final Map<String, Object> DATA = Map.of(
+            KEY_STRING, VAL_STRING,
+            KEY_INTEGER, VAL_INTEGER,
+            KEY_LIST, VAL_LIST
+    );
 
     private static final String SECRET_REQUEST_ID = "68315073-6658-e3ff-2da7-67939fb91bbd";
     private static final String SECRET_LEASE_ID = "";
@@ -104,13 +109,6 @@ class SecretResponseTest {
             "    \"warnings\": " + SECRET_WARNINGS + "\n" +
             "}";
 
-
-    static {
-        DATA.put(KEY_STRING, VAL_STRING);
-        DATA.put(KEY_INTEGER, VAL_INTEGER);
-        DATA.put(KEY_LIST, VAL_LIST);
-    }
-
     /**
      * Test getter, setter and get-methods for response data.
      *
@@ -171,7 +169,7 @@ class SecretResponseTest {
         assertNotNull(res.getMetadata().getCreatedTime(), "Creation date parsing failed");
         assertEquals("", res.getMetadata().getDeletionTimeString(), "Incorrect deletion date string");
         assertNull(res.getMetadata().getDeletionTime(), "Incorrect deletion date");
-        assertEquals(false, res.getMetadata().isDestroyed(), "Secret destroyed when not expected");
+        assertFalse(res.getMetadata().isDestroyed(), "Secret destroyed when not expected");
         assertEquals(1, res.getMetadata().getVersion(), "Incorrect secret version");
 
         // Deleted KV v2 secret.
@@ -185,8 +183,13 @@ class SecretResponseTest {
         assertNotNull(res.getMetadata().getCreatedTime(), "Creation date parsing failed");
         assertEquals(SECRET_META_DELETED, res.getMetadata().getDeletionTimeString(), "Incorrect deletion date string");
         assertNotNull(res.getMetadata().getDeletionTime(), "Incorrect deletion date");
-        assertEquals(true, res.getMetadata().isDestroyed(), "Secret destroyed when not expected");
+        assertTrue(res.getMetadata().isDestroyed(), "Secret destroyed when not expected");
         assertEquals(2, res.getMetadata().getVersion(), "Incorrect secret version");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(SecretResponse.class).verify();
     }
 
     private void assertSecretData(SecretResponse res) {

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SecretVersionResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SecretVersionResponseTest.java
@@ -17,6 +17,7 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -54,7 +55,12 @@ class SecretVersionResponseTest {
         assertNotNull(res.getMetadata(), "Parsed metadata is NULL");
         assertEquals(CREATION_TIME, res.getMetadata().getCreatedTimeString(), "Incorrect created time");
         assertEquals(DELETION_TIME, res.getMetadata().getDeletionTimeString(), "Incorrect deletion time");
-        assertEquals(false, res.getMetadata().isDestroyed(), "Incorrect destroyed state");
+        assertFalse(res.getMetadata().isDestroyed(), "Incorrect destroyed state");
         assertEquals(VERSION, res.getMetadata().getVersion(), "Incorrect version");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(SecretVersionResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/SecretVersionResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/SecretVersionResponseTest.java
@@ -16,8 +16,9 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.8
  */
-class SecretVersionResponseTest {
+class SecretVersionResponseTest extends AbstractModelTest<SecretVersionResponse> {
     private static final String CREATION_TIME = "2018-03-22T02:24:06.945319214Z";
     private static final String DELETION_TIME = "2018-03-22T02:36:43.986212308Z";
     private static final Integer VERSION = 42;
@@ -41,6 +42,20 @@ class SecretVersionResponseTest {
             "    \"version\": " + VERSION + "\n" +
             "  }\n" +
             "}";
+
+    SecretVersionResponseTest() {
+        super(SecretVersionResponse.class);
+    }
+
+    @Override
+    protected SecretVersionResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(META_JSON, SecretVersionResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
 
     /**
      * Test creation from JSON value as returned by Vault (JSON example copied from Vault documentation).
@@ -57,10 +72,5 @@ class SecretVersionResponseTest {
         assertEquals(DELETION_TIME, res.getMetadata().getDeletionTimeString(), "Incorrect deletion time");
         assertFalse(res.getMetadata().isDestroyed(), "Incorrect destroyed state");
         assertEquals(VERSION, res.getMetadata().getVersion(), "Incorrect version");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(SecretVersionResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
@@ -16,9 +16,10 @@
 
 package de.stklcode.jvault.connector.model.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.stklcode.jvault.connector.model.AbstractModelTest;
 import de.stklcode.jvault.connector.model.response.embedded.TokenData;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  * @since 0.6.2
  */
-class TokenResponseTest {
+class TokenResponseTest extends AbstractModelTest<TokenResponse> {
     private static final Integer TOKEN_CREATION_TIME = 1457533232;
     private static final Integer TOKEN_TTL = 2764800;
     private static final Integer TOKEN_EXPLICIT_MAX_TTL = 0;
@@ -88,6 +89,20 @@ class TokenResponseTest {
             "  \"auth\": null\n" +
             "}";
 
+    TokenResponseTest() {
+        super(TokenResponse.class);
+    }
+
+    @Override
+    protected TokenResponse createFull() {
+        try {
+            return new ObjectMapper().readValue(RES_JSON, TokenResponse.class);
+        } catch (JsonProcessingException e) {
+            fail("Creation of full model instance failed", e);
+            return null;
+        }
+    }
+
     /**
      * Test getter, setter and get-methods for response data.
      */
@@ -134,10 +149,5 @@ class TokenResponseTest {
         assertEquals(TOKEN_RENEWABLE, data.isRenewable(), "Incorrect token renewable flag");
         assertEquals(RES_TTL, data.getTtl(), "Incorrect token TTL");
         assertEquals(TOKEN_TYPE, data.getType(), "Incorrect token type");
-    }
-
-    @Test
-    void testEqualsHashcode() {
-        EqualsVerifier.simple().forClass(TokenResponse.class).verify();
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
@@ -17,7 +17,6 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.TokenData;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
@@ -89,8 +88,6 @@ class TokenResponseTest {
             "  \"auth\": null\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_TOKEN_DATA = Map.of("num_uses", "fourtytwo");
-
     /**
      * Test getter, setter and get-methods for response data.
      */
@@ -99,13 +96,6 @@ class TokenResponseTest {
         // Create empty Object.
         TokenResponse res = new TokenResponse();
         assertNull(res.getData(), "Initial data should be empty");
-
-        // Parsing invalid data map should fail.
-        assertThrows(
-                InvalidResponseException.class,
-                () -> res.setData(INVALID_TOKEN_DATA),
-                "Parsing invalid token data succeeded"
-        );
     }
 
     /**

--- a/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
@@ -19,10 +19,10 @@ package de.stklcode.jvault.connector.model.response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.TokenData;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -89,11 +89,7 @@ class TokenResponseTest {
             "  \"auth\": null\n" +
             "}";
 
-    private static final Map<String, Object> INVALID_TOKEN_DATA = new HashMap<>();
-
-    static {
-        INVALID_TOKEN_DATA.put("num_uses", "fourtytwo");
-    }
+    private static final Map<String, Object> INVALID_TOKEN_DATA = Map.of("num_uses", "fourtytwo");
 
     /**
      * Test getter, setter and get-methods for response data.
@@ -148,5 +144,10 @@ class TokenResponseTest {
         assertEquals(TOKEN_RENEWABLE, data.isRenewable(), "Incorrect token renewable flag");
         assertEquals(RES_TTL, data.getTtl(), "Incorrect token TTL");
         assertEquals(TOKEN_TYPE, data.getType(), "Incorrect token type");
+    }
+
+    @Test
+    void testEqualsHashcode() {
+        EqualsVerifier.simple().forClass(TokenResponse.class).verify();
     }
 }


### PR DESCRIPTION
Model classes for responses, that are mapped from JSON do implement `Serializable` now, including overridden `equals()` and `hashCode()` methods.