### PR TITLE
make system-lambda dependency test-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fix
 * Make `HTTPVaultConnectorBuilder#withPort(Integer)` null-safe (#56)
+* Make system-lambda dependency test-only (#58)
 
 ### Test
 * Tested against Vault 1.9.0

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-lambda</artifactId>
             <version>1.2.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>


### PR DESCRIPTION
The dependency is used for unit testing with mocked environment variables, so it must have `test`-scope, not `compile`.