### PR TITLE
mark deprecated AppID components for removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### Deprecations
+* AppID components (deprecated since 0.4) are marked for removal with the next major release 
+
+
 ## 1.1.2 (2022-10-26)
 
 ### Dependencies

--- a/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
@@ -201,7 +201,7 @@ public class HTTPVaultConnector implements VaultConnector {
     }
 
     @Override
-    @Deprecated(since = "0.4", forRemoval = false)
+    @Deprecated(since = "0.4", forRemoval = true)
     public final AuthResponse authAppId(final String appID, final String userID) throws VaultConnectorException {
         return queryAuth(
                 PATH_AUTH_APPID + PATH_LOGIN,
@@ -242,7 +242,7 @@ public class HTTPVaultConnector implements VaultConnector {
     }
 
     @Override
-    @Deprecated(since = "0.4", forRemoval = false)
+    @Deprecated(since = "0.4", forRemoval = true)
     public final boolean registerAppId(final String appID, final String policy, final String displayName)
             throws VaultConnectorException {
         requireAuth();
@@ -261,7 +261,7 @@ public class HTTPVaultConnector implements VaultConnector {
     }
 
     @Override
-    @Deprecated(since = "0.4", forRemoval = false)
+    @Deprecated(since = "0.4", forRemoval = true)
     public final boolean registerUserId(final String appID, final String userID) throws VaultConnectorException {
         requireAuth();
 

--- a/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
@@ -119,9 +119,10 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @param userID The User ID
      * @return The {@link AuthResponse}
      * @throws VaultConnectorException on error
-     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole. Consider using {@link #authAppRole} instead.
+     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole. App-ID was removed in Vault 1.12.
+     * Consider using {@link #authAppRole} instead.
      */
-    @Deprecated(since = "0.4", forRemoval = false)
+    @Deprecated(since = "0.4", forRemoval = true)
     AuthResponse authAppId(final String appID, final String userID) throws VaultConnectorException;
 
     /**
@@ -155,9 +156,10 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @param displayName Arbitrary name to display
      * @return {@code true} on success
      * @throws VaultConnectorException on error
-     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole. Consider using {@link #createAppRole} instead.
+     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole. App-ID was removed in Vault 1.12.
+     * Consider using {@link #createAppRole} instead.
      */
-    @Deprecated(since = "0.4", forRemoval = false)
+    @Deprecated(since = "0.4", forRemoval = true)
     boolean registerAppId(final String appID, final String policy, final String displayName)
             throws VaultConnectorException;
 
@@ -349,10 +351,10 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @param userID The User-ID
      * @return {@code true} on success
      * @throws VaultConnectorException on error
-     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole.
+     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole. App-ID was removed in Vault 1.12.
      * Consider using {@link #createAppRoleSecret} instead.
      */
-    @Deprecated(since = "0.4", forRemoval = false)
+    @Deprecated(since = "0.4", forRemoval = true)
     boolean registerUserId(final String appID, final String userID) throws VaultConnectorException;
 
     /**
@@ -364,9 +366,9 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @param userID      The User-ID
      * @return {@code true} on success
      * @throws VaultConnectorException on error
-     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole.
+     * @deprecated As of Vault 0.6.1 App-ID is superseded by AppRole. App-ID was removed in Vault 1.12.
      */
-    @Deprecated(since = "0.4", forRemoval = false)
+    @Deprecated(since = "0.4", forRemoval = true)
     default boolean registerAppUserId(final String appID,
                                       final String policy,
                                       final String displayName,

--- a/src/main/java/de/stklcode/jvault/connector/model/AuthBackend.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/AuthBackend.java
@@ -24,6 +24,7 @@ package de.stklcode.jvault.connector.model;
  */
 public enum AuthBackend {
     TOKEN("token"),
+    @Deprecated(since = "1.1.3", forRemoval = true)
     APPID("app-id"),
     APPROLE("approle"),
     USERPASS("userpass"),

--- a/src/test/java/de/stklcode/jvault/connector/model/AuthBackendTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AuthBackendTest.java
@@ -33,6 +33,7 @@ class AuthBackendTest {
      * Test forType() method.
      */
     @Test
+    @SuppressWarnings("deprecation")
     void forTypeTest() {
         assertEquals(AuthBackend.TOKEN, AuthBackend.forType("token"));
         assertEquals(AuthBackend.APPID, AuthBackend.forType("app-id"));


### PR DESCRIPTION
The AppID backend is no longer available in the latest Vault releases, so we plan removal with a following major release.

see #61 