### PR TITLE
fix timezone pattern in datetime parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+### Fix
+* Use `[+-]XX:XX` notation for timezone in date/time parsing
+
 ### Improvements
 * Use explicit UTF-8 encoding for parsing responses
 

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretMetadata.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretMetadata.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 public final class SecretMetadata implements Serializable {
     private static final long serialVersionUID = 1684891108903409038L;
 
-    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSX");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX");
 
     @JsonProperty("created_time")
     private String createdTimeString;

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/VersionMetadata.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/VersionMetadata.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 public final class VersionMetadata implements Serializable {
     private static final long serialVersionUID = -5286693953873839611L;
 
-    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSX");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX");
 
     @JsonProperty("created_time")
     private String createdTimeString;


### PR DESCRIPTION
Use `XXX` instead of `X`, i.e. expect `[+-]XX:XX` format for timezones as provided by the API.