### PR TITLE
fix type conversion in SecretResponse getter method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### Fix
+* Fixed JSON type conversion in `SecretResponse#get(String, Class)` (#67)
+
+
 ## 1.1.4 (2023-06-15)
 
 ### Fix

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.stklcode.jvault</groupId>
     <artifactId>jvault-connector</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SecretResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SecretResponse.java
@@ -79,8 +79,12 @@ public abstract class SecretResponse extends VaultDataResponse {
             Object rawValue = get(key);
             if (rawValue == null) {
                 return null;
+            } else if (type.isInstance(rawValue)) {
+                return type.cast(rawValue);
+            } else {
+                var om = new ObjectMapper();
+                return om.readValue(om.writeValueAsString(rawValue), type);
             }
-            return new ObjectMapper().readValue(rawValue.toString(), type);
         } catch (IOException e) {
             throw new InvalidResponseException("Unable to parse response payload: " + e.getMessage());
         }


### PR DESCRIPTION
Converting the payload using `toString()` is not an appropriate way to feed a JSON parser. We now use JSON roundtrip for type mapping and introduce shortcuts of the type already matches the target type.