### PR TITLE
remove redundant java.base requirement from module-info.java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Improvements
 * Parse timestamps as `ZonedDateTime` instead of `String` representation
+* Remove redundant `java.base` requirement from _module-info.java_ (#69)
 
 ### Dependencies
 * Updated Jackson to 2.16.0

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -30,7 +30,6 @@ module de.stklcode.jvault.connector {
     opens de.stklcode.jvault.connector.model.response to com.fasterxml.jackson.databind;
     opens de.stklcode.jvault.connector.model.response.embedded to com.fasterxml.jackson.databind;
 
-    requires java.base;
     requires java.net.http;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.datatype.jsr310;


### PR DESCRIPTION
`java.base` is implicitly imported in every module. No need to specify it explicitly here.