### PR TITLE
close HTTPClient when running with JDK21 or newer (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         jdk: [ 11, 17, 21 ]
         vault: [ '1.2.0', '1.11.12', '1.15.0' ]
         include:
-          - jdk: 17
+          - jdk: 21
             vault: '1.11.12'
             analysis: true
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Improvements
 * Parse timestamps as `ZonedDateTime` instead of `String` representation
 * Remove redundant `java.base` requirement from _module-info.java_ (#69)
+* Close Java HTTP Client when running on Java 21 or later (#70)
 
 ### Dependencies
 * Updated Jackson to 2.16.0

--- a/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
+++ b/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
@@ -363,6 +363,15 @@ public final class RequestHelper implements Serializable {
             }
         } catch (CompletionException e) {
             throw new ConnectionException(Error.CONNECTION, e.getCause());
+        } finally {
+            if (client instanceof AutoCloseable) {
+                // Close the client, which is supported since JDK21.
+                try {
+                    ((AutoCloseable) client).close();
+                } catch (Exception ignored) {
+                    // Ignore
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The Java HTTP client implements `AutoCloseable` since JDK 21. Closing the client ensures that asynchronous operations and streams are properly terminated.

As we support Java 11, we add any old school `finally` wrapper and conditionally close the client when running on a modern platform.