### PR TITLE
model: add MFA requirement data to auth response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Parse timestamps as `ZonedDateTime` instead of `String` representation
 * Remove redundant `java.base` requirement from _module-info.java_ (#69)
 * Close Java HTTP Client when running on Java 21 or later (#70)
+* Add MFA requirements tu `AuthResponse` (#71)
 
 ### Dependencies
 * Updated Jackson to 2.16.0

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
@@ -65,6 +65,9 @@ public final class AuthData implements Serializable {
     @JsonProperty("orphan")
     private boolean orphan;
 
+    @JsonProperty("mfa_requirement")
+    private MfaRequirement mfaRequirement;
+
     /**
      * @return Client token
      */
@@ -139,6 +142,14 @@ public final class AuthData implements Serializable {
         return orphan;
     }
 
+    /**
+     * @return multi-factor requirement
+     * @since 1.2
+     */
+    public MfaRequirement getMfaRequirement() {
+        return mfaRequirement;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -157,12 +168,13 @@ public final class AuthData implements Serializable {
                 Objects.equals(metadata, authData.metadata) &&
                 Objects.equals(leaseDuration, authData.leaseDuration) &&
                 Objects.equals(entityId, authData.entityId) &&
-                Objects.equals(tokenType, authData.tokenType);
+                Objects.equals(tokenType, authData.tokenType) &&
+                Objects.equals(mfaRequirement, authData.mfaRequirement);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(clientToken, accessor, policies, tokenPolicies, metadata, leaseDuration, renewable,
-                entityId, tokenType, orphan);
+                entityId, tokenType, orphan, mfaRequirement);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MfaConstraintAny.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MfaConstraintAny.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-2023 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model.response.embedded;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Embedded multi-factor-authentication (MFA) constraint "any".
+ *
+ * @author Stefan Kalscheuer
+ * @since 1.2
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class MfaConstraintAny implements Serializable {
+    private static final long serialVersionUID = 1226126781813149627L;
+
+    @JsonProperty("any")
+    private List<MfaMethodId> any;
+
+    /**
+     * @return List of "any" MFA methods
+     */
+    public List<MfaMethodId> getAny() {
+        return any;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MfaConstraintAny mfaRequirement = (MfaConstraintAny) o;
+        return Objects.equals(any, mfaRequirement.any);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(any);
+    }
+}

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MfaMethodId.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MfaMethodId.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016-2023 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model.response.embedded;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Embedded multi-factor-authentication (MFA) requirement.
+ *
+ * @author Stefan Kalscheuer
+ * @since 1.2
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class MfaMethodId implements Serializable {
+    private static final long serialVersionUID = 691298070242998814L;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("uses_passcode")
+    private Boolean usesPasscode;
+
+    @JsonProperty("name")
+    private String name;
+
+    /**
+     * @return MFA method type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return MFA method id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return MFA uses passcode id
+     */
+    public Boolean getUsesPasscode() {
+        return usesPasscode;
+    }
+
+    /**
+     * @return MFA method name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MfaMethodId mfaMethodId = (MfaMethodId) o;
+        return Objects.equals(type, mfaMethodId.type) &&
+            Objects.equals(id, mfaMethodId.id) &&
+            Objects.equals(usesPasscode, mfaMethodId.usesPasscode) &&
+            Objects.equals(name, mfaMethodId.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, id, usesPasscode, name);
+    }
+}

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MfaRequirement.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MfaRequirement.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-2023 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector.model.response.embedded;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Embedded multi-factor-authentication (MFA) requirement.
+ *
+ * @author Stefan Kalscheuer
+ * @since 1.2
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class MfaRequirement implements Serializable {
+    private static final long serialVersionUID = -2516941512455319638L;
+
+    @JsonProperty("mfa_request_id")
+    private String mfaRequestId;
+
+    @JsonProperty("mfa_constraints")
+    private Map<String, MfaConstraintAny> mfaConstraints;
+
+    /**
+     * @return MFA request ID
+     */
+    public String getMfaRequestId() {
+        return mfaRequestId;
+    }
+
+    /**
+     * @return MFA constraints
+     */
+    public Map<String, MfaConstraintAny> getMfaConstraints() {
+        return mfaConstraints;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MfaRequirement mfaRequirement = (MfaRequirement) o;
+        return Objects.equals(mfaRequestId, mfaRequirement.mfaRequestId) &&
+            Objects.equals(mfaConstraints, mfaRequirement.mfaConstraints);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mfaRequestId, mfaConstraints);
+    }
+}


### PR DESCRIPTION
The "Login MFA"[1] feature is available since Vault 1.10 

If enabled, requirement information is added to the `AuthResponse`:
```json
    "mfa_requirement": {
      "mfa_request_id": "d0c9eec7-6921-8cc0-be62-202b289ef163",
      "mfa_constraints": {
        "enforcementConfigUserpass": {
          "any": [
            {
              "type": "totp",
              "id": "820997b3-110e-c251-7e8b-ff4aa428a6e1",
              "uses_passcode": true,
              "name": "sample_mfa_method_name",
            }
          ]
        }
      }
    }
```

We do _not_ yet support MFA login, just transport the information for now.

----

[1] https://developer.hashicorp.com/vault/docs/auth/login-mfa