### PR TITLE
add missing and new attributes for Vault 1.16 and 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `enterprise`
 * Add missing `num_uses` field to `AuthData`
 * Add `mount_type` attribute to common response model
+* Add `auth` attribute to common response model
 
 ### Dependencies
 * Updated Jackson to 2.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * `replication_primary_canary_age_ms`
   * `enterprise`
 * Add missing `num_uses` field to `AuthData`
+* Add `mount_type` attribute to common response model
 
 ### Dependencies
 * Updated Jackson to 2.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add missing `num_uses` field to `AuthData`
 * Add `mount_type` attribute to common response model
 * Add `auth` attribute to common response model
+* Add `custom_metadata`, `cas_required` and `delete_version_after` fields for KVv2 metadata
 
 ### Fix
 * Rename `enable_local_secret_id` to `local_secret_ids` in `AppRole` model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Add `mount_type` attribute to common response model
 * Add `auth` attribute to common response model
 
+### Fix
+* Rename `enable_local_secret_id` to `local_secret_ids` in `AppRole` model
+
 ### Dependencies
 * Updated Jackson to 2.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+* Simplify JSON parsing in error handler
+* Add new fields from Vault 1.16 and 1.17 to `HealthResponse`
+    * `echo_duration_ms`
+    * `clock_skew_ms`
+    * `replication_primary_canary_age_ms`
+    * `enterprise`
+
+### Dependencies
+* Updated Jackson to 2.17.1
+
+### Test
+* Tested against Vault 1.2 to 1.17
+
+
 ## 1.2.0 (2023-12-11)
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+## unreleased
+
+### Improvements
 * Simplify JSON parsing in error handler
 * Add new fields from Vault 1.16 and 1.17 to `HealthResponse`
-    * `echo_duration_ms`
-    * `clock_skew_ms`
-    * `replication_primary_canary_age_ms`
-    * `enterprise`
+  * `echo_duration_ms`
+  * `clock_skew_ms`
+  * `replication_primary_canary_age_ms`
+  * `enterprise`
+* Add missing `num_uses` field to `AuthData`
 
 ### Dependencies
 * Updated Jackson to 2.17.1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.stklcode.jvault</groupId>
     <artifactId>jvault-connector</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AppRole implements Serializable {
-    private static final long serialVersionUID = -6248529625864573990L;
+    private static final long serialVersionUID = 693228837510483448L;
 
     @JsonProperty("role_name")
     private String name;
@@ -55,9 +55,9 @@ public final class AppRole implements Serializable {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer secretIdTtl;
 
-    @JsonProperty("enable_local_secret_ids")
+    @JsonProperty("local_secret_ids")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Boolean enableLocalSecretIds;
+    private Boolean localSecretIds;
 
     @JsonProperty("token_ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -111,7 +111,7 @@ public final class AppRole implements Serializable {
         this.secretIdBoundCidrs = builder.secretIdBoundCidrs;
         this.secretIdNumUses = builder.secretIdNumUses;
         this.secretIdTtl = builder.secretIdTtl;
-        this.enableLocalSecretIds = builder.enableLocalSecretIds;
+        this.localSecretIds = builder.localSecretIds;
         this.tokenTtl = builder.tokenTtl;
         this.tokenMaxTtl = builder.tokenMaxTtl;
         this.tokenPolicies = builder.tokenPolicies;
@@ -262,9 +262,10 @@ public final class AppRole implements Serializable {
     /**
      * @return Enable local secret IDs?
      * @since 0.9
+     * @since 1.3 renamed to {@code getLocalSecretIds()}
      */
-    public Boolean getEnableLocalSecretIds() {
-        return enableLocalSecretIds;
+    public Boolean getLocalSecretIds() {
+        return localSecretIds;
     }
 
     /**
@@ -335,7 +336,7 @@ public final class AppRole implements Serializable {
                 Objects.equals(secretIdBoundCidrs, appRole.secretIdBoundCidrs) &&
                 Objects.equals(secretIdNumUses, appRole.secretIdNumUses) &&
                 Objects.equals(secretIdTtl, appRole.secretIdTtl) &&
-                Objects.equals(enableLocalSecretIds, appRole.enableLocalSecretIds) &&
+                Objects.equals(localSecretIds, appRole.localSecretIds) &&
                 Objects.equals(tokenTtl, appRole.tokenTtl) &&
                 Objects.equals(tokenMaxTtl, appRole.tokenMaxTtl) &&
                 Objects.equals(tokenPolicies, appRole.tokenPolicies) &&
@@ -350,7 +351,7 @@ public final class AppRole implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(name, id, bindSecretId, secretIdBoundCidrs, secretIdNumUses, secretIdTtl,
-                enableLocalSecretIds, tokenTtl, tokenMaxTtl, tokenPolicies, tokenBoundCidrs, tokenExplicitMaxTtl,
+                localSecretIds, tokenTtl, tokenMaxTtl, tokenPolicies, tokenBoundCidrs, tokenExplicitMaxTtl,
                 tokenNoDefaultPolicy, tokenNumUses, tokenPeriod, tokenType);
     }
 
@@ -370,7 +371,7 @@ public final class AppRole implements Serializable {
         private List<String> tokenPolicies;
         private Integer secretIdNumUses;
         private Integer secretIdTtl;
-        private Boolean enableLocalSecretIds;
+        private Boolean localSecretIds;
         private Integer tokenTtl;
         private Integer tokenMaxTtl;
         private List<String> tokenBoundCidrs;
@@ -527,12 +528,13 @@ public final class AppRole implements Serializable {
         /**
          * Enable or disable local secret IDs.
          *
-         * @param enableLocalSecretIds Enable local secret IDs?
+         * @param localSecretIds Enable local secret IDs?
          * @return self
          * @since 0.9
+         * @since 1.3 renamed to {@code withLocalSecretIds()}
          */
-        public Builder withEnableLocalSecretIds(final Boolean enableLocalSecretIds) {
-            this.enableLocalSecretIds = enableLocalSecretIds;
+        public Builder withLocalSecretIds(final Boolean localSecretIds) {
+            this.localSecretIds = localSecretIds;
             return this;
         }
 

--- a/src/main/java/de/stklcode/jvault/connector/model/response/AuthResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/AuthResponse.java
@@ -17,10 +17,7 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import de.stklcode.jvault.connector.model.response.embedded.AuthData;
-
-import java.util.Objects;
 
 /**
  * Vault response for authentication providing auth info in {@link AuthData} field.
@@ -31,30 +28,4 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AuthResponse extends VaultDataResponse {
     private static final long serialVersionUID = 1628851361067456715L;
-
-    @JsonProperty("auth")
-    private AuthData auth;
-
-    /**
-     * @return Authentication data
-     */
-    public AuthData getAuth() {
-        return auth;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        } else if (o == null || getClass() != o.getClass() || !super.equals(o)) {
-            return false;
-        }
-        AuthResponse that = (AuthResponse) o;
-        return Objects.equals(auth, that.auth);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), auth);
-    }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/HealthResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/HealthResponse.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class HealthResponse implements VaultResponse {
-    private static final long serialVersionUID = 6483840078694294401L;
+    private static final long serialVersionUID = 8675155916902904516L;
 
     @JsonProperty("cluster_id")
     private String clusterID;
@@ -60,6 +60,18 @@ public final class HealthResponse implements VaultResponse {
 
     @JsonProperty("performance_standby")
     private Boolean performanceStandby;
+
+    @JsonProperty("echo_duration_ms")
+    private Long echoDurationMs;
+
+    @JsonProperty("clock_skew_ms")
+    private Long clockSkewMs;
+
+    @JsonProperty("replication_primary_canary_age_ms")
+    private Long replicationPrimaryCanaryAgeMs;
+
+    @JsonProperty("enterprise")
+    private Boolean enterprise;
 
     /**
      * @return The Cluster ID.
@@ -134,6 +146,38 @@ public final class HealthResponse implements VaultResponse {
         return performanceStandby;
     }
 
+    /**
+     * @return Heartbeat echo duration in milliseconds (since Vault 1.16)
+     * @since 1.3
+     */
+    public Long getEchoDurationMs() {
+        return echoDurationMs;
+    }
+
+    /**
+     * @return Clock skew in milliseconds (since Vault 1.16)
+     * @since 1.3
+     */
+    public Long getClockSkewMs() {
+        return clockSkewMs;
+    }
+
+    /**
+     * @return Replication primary canary age in milliseconds (since Vault 1.17)
+     * @since 1.3
+     */
+    public Long getReplicationPrimaryCanaryAgeMs() {
+        return replicationPrimaryCanaryAgeMs;
+    }
+
+    /**
+     * @return Enterprise instance? (since Vault 1.17)
+     * @since 1.3
+     */
+    public Boolean isEnterprise() {
+        return enterprise;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -151,12 +195,17 @@ public final class HealthResponse implements VaultResponse {
                 Objects.equals(initialized, that.initialized) &&
                 Objects.equals(replicationPerfMode, that.replicationPerfMode) &&
                 Objects.equals(replicationDrMode, that.replicationDrMode) &&
-                Objects.equals(performanceStandby, that.performanceStandby);
+                Objects.equals(performanceStandby, that.performanceStandby) &&
+                Objects.equals(echoDurationMs, that.echoDurationMs) &&
+                Objects.equals(clockSkewMs, that.clockSkewMs) &&
+                Objects.equals(replicationPrimaryCanaryAgeMs, that.replicationPrimaryCanaryAgeMs) &&
+                Objects.equals(enterprise, that.enterprise);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(clusterID, clusterName, version, serverTimeUTC, standby, sealed, initialized,
-                replicationPerfMode, replicationDrMode, performanceStandby);
+            replicationPerfMode, replicationDrMode, performanceStandby, echoDurationMs, clockSkewMs,
+            replicationPrimaryCanaryAgeMs, enterprise);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/TokenResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/TokenResponse.java
@@ -30,13 +30,10 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TokenResponse extends VaultDataResponse {
-    private static final long serialVersionUID = -4053126653764241197L;
+    private static final long serialVersionUID = -4341114947980033457L;
 
     @JsonProperty("data")
     private TokenData data;
-
-    @JsonProperty("auth")
-    private Boolean auth;
 
     /**
      * @return Token data
@@ -45,12 +42,6 @@ public final class TokenResponse extends VaultDataResponse {
         return data;
     }
 
-    /**
-     * @return Auth data
-     */
-    public Boolean getAuth() {
-        return auth;
-    }
 
     @Override
     public boolean equals(Object o) {
@@ -60,11 +51,11 @@ public final class TokenResponse extends VaultDataResponse {
             return false;
         }
         TokenResponse that = (TokenResponse) o;
-        return Objects.equals(data, that.data) && Objects.equals(auth, that.auth);
+        return Objects.equals(data, that.data);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), data, auth);
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * @since 0.1
  */
 public abstract class VaultDataResponse implements VaultResponse {
-    private static final long serialVersionUID = 7486270767477652184L;
+    private static final long serialVersionUID = -6396903229092254181L;
 
     @JsonProperty("request_id")
     private String requestId;
@@ -48,6 +48,9 @@ public abstract class VaultDataResponse implements VaultResponse {
 
     @JsonProperty("wrap_info")
     private WrapInfo wrapInfo;
+
+    @JsonProperty("mount_type")
+    private String mountType;
 
     /**
      * @return Request ID
@@ -93,6 +96,13 @@ public abstract class VaultDataResponse implements VaultResponse {
         return wrapInfo;
     }
 
+    /**
+     * @return Information about the type of mount this secret is from (since Vault 1.17)
+     * @since 1.3
+     */
+    public final String getMountType() {
+        return mountType;
+    }
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -106,11 +116,12 @@ public abstract class VaultDataResponse implements VaultResponse {
                 Objects.equals(leaseId, that.leaseId) &&
                 Objects.equals(leaseDuration, that.leaseDuration) &&
                 Objects.equals(warnings, that.warnings) &&
-                Objects.equals(wrapInfo, that.wrapInfo);
+                Objects.equals(wrapInfo, that.wrapInfo) &&
+                Objects.equals(mountType, that.mountType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requestId, leaseId, renewable, leaseDuration, warnings, wrapInfo);
+        return Objects.hash(requestId, leaseId, renewable, leaseDuration, warnings, wrapInfo, mountType);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/VaultDataResponse.java
@@ -17,6 +17,7 @@
 package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.stklcode.jvault.connector.model.response.embedded.AuthData;
 import de.stklcode.jvault.connector.model.response.embedded.WrapInfo;
 
 import java.util.List;
@@ -29,7 +30,7 @@ import java.util.Objects;
  * @since 0.1
  */
 public abstract class VaultDataResponse implements VaultResponse {
-    private static final long serialVersionUID = -6396903229092254181L;
+    private static final long serialVersionUID = 4787715235558510045L;
 
     @JsonProperty("request_id")
     private String requestId;
@@ -48,6 +49,9 @@ public abstract class VaultDataResponse implements VaultResponse {
 
     @JsonProperty("wrap_info")
     private WrapInfo wrapInfo;
+
+    @JsonProperty("auth")
+    private AuthData auth;
 
     @JsonProperty("mount_type")
     private String mountType;
@@ -97,6 +101,14 @@ public abstract class VaultDataResponse implements VaultResponse {
     }
 
     /**
+     * @return Authentication information for this response
+     * @since 1.3
+     */
+    public final AuthData getAuth() {
+        return auth;
+    }
+
+    /**
      * @return Information about the type of mount this secret is from (since Vault 1.17)
      * @since 1.3
      */
@@ -117,11 +129,12 @@ public abstract class VaultDataResponse implements VaultResponse {
                 Objects.equals(leaseDuration, that.leaseDuration) &&
                 Objects.equals(warnings, that.warnings) &&
                 Objects.equals(wrapInfo, that.wrapInfo) &&
+                Objects.equals(auth, that.auth) &&
                 Objects.equals(mountType, that.mountType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requestId, leaseId, renewable, leaseDuration, warnings, wrapInfo, mountType);
+        return Objects.hash(requestId, leaseId, renewable, leaseDuration, warnings, wrapInfo, auth, mountType);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/AuthData.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AuthData implements Serializable {
-    private static final long serialVersionUID = 3067695351664603536L;
+    private static final long serialVersionUID = 5969334512309655317L;
 
     @JsonProperty("client_token")
     private String clientToken;
@@ -64,6 +64,9 @@ public final class AuthData implements Serializable {
 
     @JsonProperty("orphan")
     private boolean orphan;
+
+    @JsonProperty("num_uses")
+    private Integer numUses;
 
     @JsonProperty("mfa_requirement")
     private MfaRequirement mfaRequirement;
@@ -135,6 +138,14 @@ public final class AuthData implements Serializable {
     }
 
     /**
+     * @return allowed number of uses for the issued token
+     * @since 1.3
+     */
+    public Integer getNumUses() {
+        return numUses;
+    }
+
+    /**
      * @return Token is orphan
      * @since 0.9
      */
@@ -169,12 +180,13 @@ public final class AuthData implements Serializable {
                 Objects.equals(leaseDuration, authData.leaseDuration) &&
                 Objects.equals(entityId, authData.entityId) &&
                 Objects.equals(tokenType, authData.tokenType) &&
+                Objects.equals(numUses, authData.numUses) &&
                 Objects.equals(mfaRequirement, authData.mfaRequirement);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(clientToken, accessor, policies, tokenPolicies, metadata, leaseDuration, renewable,
-                entityId, tokenType, orphan, mfaRequirement);
+                entityId, tokenType, orphan, numUses, mfaRequirement);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretMetadata.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/SecretMetadata.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -34,7 +35,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SecretMetadata implements Serializable {
-    private static final long serialVersionUID = -4967896264361344676L;
+    private static final long serialVersionUID = -905059942871916214L;
 
     private static final DateTimeFormatter TIME_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX");
@@ -56,6 +57,15 @@ public final class SecretMetadata implements Serializable {
 
     @JsonProperty("versions")
     private Map<Integer, VersionMetadata> versions;
+
+    @JsonProperty("cas_required")
+    private Boolean casRequired;
+
+    @JsonProperty("custom_metadata")
+    private HashMap<String, String> customMetadata;
+
+    @JsonProperty("delete_version_after")
+    private String deleteVersionAfter;
 
     /**
      * @return Time of secret creation as raw string representation.
@@ -125,6 +135,30 @@ public final class SecretMetadata implements Serializable {
         return versions;
     }
 
+    /**
+     * @return CAS required?
+     * @since 1.3
+     */
+    public Boolean isCasRequired() {
+        return casRequired;
+    }
+
+    /**
+     * @return Custom metadata.
+     * @since 1.3
+     */
+    public Map<String, String> getCustomMetadata() {
+        return customMetadata;
+    }
+
+    /**
+     * @return time duration to delete version
+     * @since 1.3
+     */
+    public String getDeleteVersionAfter() {
+        return deleteVersionAfter;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -138,11 +172,15 @@ public final class SecretMetadata implements Serializable {
                 Objects.equals(maxVersions, that.maxVersions) &&
                 Objects.equals(oldestVersion, that.oldestVersion) &&
                 Objects.equals(updatedTime, that.updatedTime) &&
-                Objects.equals(versions, that.versions);
+                Objects.equals(versions, that.versions) &&
+                Objects.equals(casRequired, that.casRequired) &&
+                Objects.equals(customMetadata, that.customMetadata) &&
+                Objects.equals(deleteVersionAfter, that.deleteVersionAfter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(createdTime, currentVersion, maxVersions, oldestVersion, updatedTime, versions);
+        return Objects.hash(createdTime, currentVersion, maxVersions, oldestVersion, updatedTime, versions, casRequired,
+            customMetadata, deleteVersionAfter);
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/VersionMetadata.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/VersionMetadata.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -33,7 +35,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class VersionMetadata implements Serializable {
-    private static final long serialVersionUID = -6815731513868586713L;
+    private static final long serialVersionUID = 8495687554714216478L;
 
     private static final DateTimeFormatter TIME_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX");
@@ -49,6 +51,9 @@ public final class VersionMetadata implements Serializable {
 
     @JsonProperty("version")
     private Integer version;
+
+    @JsonProperty("custom_metadata")
+    private HashMap<String, String> customMetadata;
 
     /**
      * @return Time of secret creation as raw string representation.
@@ -104,6 +109,14 @@ public final class VersionMetadata implements Serializable {
         return version;
     }
 
+    /**
+     * @return Custom metadata.
+     * @since 1.3
+     */
+    public Map<String, String> getCustomMetadata() {
+        return customMetadata;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -115,11 +128,12 @@ public final class VersionMetadata implements Serializable {
         return destroyed == that.destroyed &&
                 Objects.equals(createdTime, that.createdTime) &&
                 Objects.equals(deletionTime, that.deletionTime) &&
-                Objects.equals(version, that.version);
+                Objects.equals(version, that.version) &&
+                Objects.equals(customMetadata, that.customMetadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(createdTime, deletionTime, destroyed, version);
+        return Objects.hash(createdTime, deletionTime, destroyed, version, customMetadata);
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
@@ -43,7 +43,7 @@ class AppRoleTest extends AbstractModelTest<AppRole> {
     private static final String POLICY_2 = "policy2";
     private static final Integer SECRET_ID_NUM_USES = 10;
     private static final Integer SECRET_ID_TTL = 7200;
-    private static final Boolean ENABLE_LOCAL_SECRET_IDS = false;
+    private static final Boolean LOCAL_SECRET_IDS = false;
     private static final Integer TOKEN_TTL = 4800;
     private static final Integer TOKEN_MAX_TTL = 9600;
     private static final Integer TOKEN_EXPLICIT_MAX_TTL = 14400;
@@ -52,8 +52,8 @@ class AppRoleTest extends AbstractModelTest<AppRole> {
     private static final Integer TOKEN_PERIOD = 1234;
     private static final Token.Type TOKEN_TYPE = Token.Type.DEFAULT_SERVICE;
     private static final String JSON_MIN = "{\"role_name\":\"" + NAME + "\"}";
-    private static final String JSON_FULL = String.format("{\"role_name\":\"%s\",\"role_id\":\"%s\",\"bind_secret_id\":%s,\"secret_id_bound_cidrs\":\"%s\",\"secret_id_num_uses\":%d,\"secret_id_ttl\":%d,\"enable_local_secret_ids\":%s,\"token_ttl\":%d,\"token_max_ttl\":%d,\"token_policies\":\"%s\",\"token_bound_cidrs\":\"%s\",\"token_explicit_max_ttl\":%d,\"token_no_default_policy\":%s,\"token_num_uses\":%d,\"token_period\":%d,\"token_type\":\"%s\"}",
-            NAME, ID, BIND_SECRET_ID, CIDR_1, SECRET_ID_NUM_USES, SECRET_ID_TTL, ENABLE_LOCAL_SECRET_IDS, TOKEN_TTL, TOKEN_MAX_TTL, POLICY, CIDR_1, TOKEN_EXPLICIT_MAX_TTL, TOKEN_NO_DEFAULT_POLICY, TOKEN_NUM_USES, TOKEN_PERIOD, TOKEN_TYPE.value());
+    private static final String JSON_FULL = String.format("{\"role_name\":\"%s\",\"role_id\":\"%s\",\"bind_secret_id\":%s,\"secret_id_bound_cidrs\":\"%s\",\"secret_id_num_uses\":%d,\"secret_id_ttl\":%d,\"local_secret_ids\":%s,\"token_ttl\":%d,\"token_max_ttl\":%d,\"token_policies\":\"%s\",\"token_bound_cidrs\":\"%s\",\"token_explicit_max_ttl\":%d,\"token_no_default_policy\":%s,\"token_num_uses\":%d,\"token_period\":%d,\"token_type\":\"%s\"}",
+            NAME, ID, BIND_SECRET_ID, CIDR_1, SECRET_ID_NUM_USES, SECRET_ID_TTL, LOCAL_SECRET_IDS, TOKEN_TTL, TOKEN_MAX_TTL, POLICY, CIDR_1, TOKEN_EXPLICIT_MAX_TTL, TOKEN_NO_DEFAULT_POLICY, TOKEN_NUM_USES, TOKEN_PERIOD, TOKEN_TYPE.value());
 
     AppRoleTest() {
         super(AppRole.class);
@@ -68,7 +68,7 @@ class AppRoleTest extends AbstractModelTest<AppRole> {
                 .withTokenPolicies(POLICIES)
                 .withSecretIdNumUses(SECRET_ID_NUM_USES)
                 .withSecretIdTtl(SECRET_ID_TTL)
-                .withEnableLocalSecretIds(ENABLE_LOCAL_SECRET_IDS)
+                .withLocalSecretIds(LOCAL_SECRET_IDS)
                 .withTokenTtl(TOKEN_TTL)
                 .withTokenMaxTtl(TOKEN_MAX_TTL)
                 .withTokenBoundCidrs(BOUND_CIDR_LIST)
@@ -98,7 +98,7 @@ class AppRoleTest extends AbstractModelTest<AppRole> {
         assertNull(role.getTokenPolicies());
         assertNull(role.getSecretIdNumUses());
         assertNull(role.getSecretIdTtl());
-        assertNull(role.getEnableLocalSecretIds());
+        assertNull(role.getLocalSecretIds());
         assertNull(role.getTokenTtl());
         assertNull(role.getTokenMaxTtl());
         assertNull(role.getTokenBoundCidrs());
@@ -125,7 +125,7 @@ class AppRoleTest extends AbstractModelTest<AppRole> {
         assertEquals(POLICIES, role.getTokenPolicies());
         assertEquals(SECRET_ID_NUM_USES, role.getSecretIdNumUses());
         assertEquals(SECRET_ID_TTL, role.getSecretIdTtl());
-        assertEquals(ENABLE_LOCAL_SECRET_IDS, role.getEnableLocalSecretIds());
+        assertEquals(LOCAL_SECRET_IDS, role.getLocalSecretIds());
         assertEquals(TOKEN_TTL, role.getTokenTtl());
         assertEquals(TOKEN_MAX_TTL, role.getTokenMaxTtl());
         assertEquals(BOUND_CIDR_LIST, role.getTokenBoundCidrs());

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthResponseTest.java
@@ -48,6 +48,7 @@ class AuthResponseTest extends AbstractModelTest<AuthResponse> {
     private static final String AUTH_ENTITY_ID = "";
     private static final String AUTH_TOKEN_TYPE = "service";
     private static final Boolean AUTH_ORPHAN = false;
+    private static final Integer AUTH_NUM_USES = 42;
     private static final String MFA_REQUEST_ID = "d0c9eec7-6921-8cc0-be62-202b289ef163";
     private static final String MFA_KEY = "enforcementConfigUserpass";
     private static final String MFA_METHOD_TYPE = "totp";
@@ -75,6 +76,7 @@ class AuthResponseTest extends AbstractModelTest<AuthResponse> {
         "    \"entity_id\": \"" + AUTH_ENTITY_ID + "\",\n" +
         "    \"token_type\": \"" + AUTH_TOKEN_TYPE + "\",\n" +
         "    \"orphan\": " + AUTH_ORPHAN + ",\n" +
+        "    \"num_uses\": " + AUTH_NUM_USES + ",\n" +
         "    \"mfa_requirement\": {\n" +
         "      \"mfa_request_id\": \"" + MFA_REQUEST_ID + "\",\n" +
         "      \"mfa_constraints\": {\n" +
@@ -134,6 +136,7 @@ class AuthResponseTest extends AbstractModelTest<AuthResponse> {
         assertEquals(AUTH_ORPHAN, data.isOrphan(), "Incorrect auth orphan flag");
         assertEquals(AUTH_TOKEN_TYPE, data.getTokenType(), "Incorrect auth token type");
         assertEquals(AUTH_ENTITY_ID, data.getEntityId(), "Incorrect auth entity id");
+        assertEquals(AUTH_NUM_USES, data.getNumUses(), "Incorrect auth num uses");
         assertEquals(2, data.getPolicies().size(), "Incorrect number of policies");
         assertTrue(data.getPolicies().containsAll(Set.of(AUTH_POLICY_1, AUTH_POLICY_2)));
         assertEquals(2, data.getTokenPolicies().size(), "Incorrect number of token policies");

--- a/src/test/java/de/stklcode/jvault/connector/model/response/HealthResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/HealthResponseTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class HealthResponseTest extends AbstractModelTest<HealthResponse> {
     private static final String CLUSTER_ID = "c9abceea-4f46-4dab-a688-5ce55f89e228";
     private static final String CLUSTER_NAME = "vault-cluster-5515c810";
-    private static final String VERSION = "0.9.2";
+    private static final String VERSION = "0.17.0";
     private static final Long SERVER_TIME_UTC = 1469555798L;
     private static final Boolean STANDBY = false;
     private static final Boolean SEALED = false;
@@ -39,6 +39,10 @@ class HealthResponseTest extends AbstractModelTest<HealthResponse> {
     private static final Boolean PERF_STANDBY = false;
     private static final String REPL_PERF_MODE = "disabled";
     private static final String REPL_DR_MODE = "disabled";
+    private static final Long ECHO_DURATION = 1L;
+    private static final Long CLOCK_SKEW = 0L;
+    private static final Long REPL_PRIM_CANARY_AGE = 2L;
+    private static final Boolean ENTERPRISE = false;
 
     private static final String RES_JSON = "{\n" +
             "  \"cluster_id\": \"" + CLUSTER_ID + "\",\n" +
@@ -50,7 +54,11 @@ class HealthResponseTest extends AbstractModelTest<HealthResponse> {
             "  \"initialized\": " + INITIALIZED + ",\n" +
             "  \"replication_performance_mode\": \"" + REPL_PERF_MODE + "\",\n" +
             "  \"replication_dr_mode\": \"" + REPL_DR_MODE + "\",\n" +
-            "  \"performance_standby\": " + PERF_STANDBY + "\n" +
+            "  \"performance_standby\": " + PERF_STANDBY + ",\n" +
+            "  \"echo_duration_ms\": " + ECHO_DURATION + ",\n" +
+            "  \"clock_skew_ms\": " + CLOCK_SKEW + ",\n" +
+            "  \"replication_primary_canary_age_ms\": " + REPL_PRIM_CANARY_AGE + ",\n" +
+            "  \"enterprise\": " + ENTERPRISE + "\n" +
             "}";
 
     HealthResponseTest() {
@@ -87,5 +95,9 @@ class HealthResponseTest extends AbstractModelTest<HealthResponse> {
         assertEquals(PERF_STANDBY, res.isPerformanceStandby(), "Incorrect performance standby state");
         assertEquals(REPL_PERF_MODE, res.getReplicationPerfMode(), "Incorrect replication perf mode");
         assertEquals(REPL_DR_MODE, res.getReplicationDrMode(), "Incorrect replication DR mode");
+        assertEquals(ECHO_DURATION, res.getEchoDurationMs(), "Incorrect echo duration");
+        assertEquals(CLOCK_SKEW, res.getClockSkewMs(), "Incorrect clock skew");
+        assertEquals(REPL_PRIM_CANARY_AGE, res.getReplicationPrimaryCanaryAgeMs(), "Incorrect canary age");
+        assertEquals(ENTERPRISE, res.isEnterprise(), "Incorrect enterprise flag");
     }
 }

--- a/src/test/java/de/stklcode/jvault/connector/model/response/MetaSecretResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/MetaSecretResponseTest.java
@@ -21,6 +21,7 @@ import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,6 +43,9 @@ class MetaSecretResponseTest extends AbstractModelTest<MetaSecretResponse> {
     private static final String SECRET_META_CREATED = "2018-03-22T02:24:06.945319214Z";
     private static final String SECRET_META_DELETED = "2018-03-23T03:25:07.056420325Z";
     private static final List<String> SECRET_WARNINGS = null;
+    private static final String CUSTOM_META_KEY = "foo";
+    private static final String CUSTOM_META_VAL = "bar";
+
     private static final String SECRET_JSON_V2 = "{\n" +
             "    \"request_id\": \"" + SECRET_REQUEST_ID + "\",\n" +
             "    \"lease_id\": \"" + SECRET_LEASE_ID + "\",\n" +
@@ -54,6 +58,7 @@ class MetaSecretResponseTest extends AbstractModelTest<MetaSecretResponse> {
             "      },\n" +
             "      \"metadata\": {\n" +
             "          \"created_time\": \"" + SECRET_META_CREATED + "\",\n" +
+            "          \"custom_metadata\": null,\n" +
             "          \"deletion_time\": \"\",\n" +
             "          \"destroyed\": false,\n" +
             "          \"version\": 1\n" +
@@ -73,6 +78,9 @@ class MetaSecretResponseTest extends AbstractModelTest<MetaSecretResponse> {
             "      },\n" +
             "      \"metadata\": {\n" +
             "          \"created_time\": \"" + SECRET_META_CREATED + "\",\n" +
+            "          \"custom_metadata\": {" +
+            "            \"" + CUSTOM_META_KEY + "\": \"" + CUSTOM_META_VAL + "\"" +
+            "          },\n" +
             "          \"deletion_time\": \"" + SECRET_META_DELETED + "\",\n" +
             "          \"destroyed\": true,\n" +
             "          \"version\": 2\n" +
@@ -113,6 +121,7 @@ class MetaSecretResponseTest extends AbstractModelTest<MetaSecretResponse> {
         assertNull(res.getMetadata().getDeletionTime(), "Incorrect deletion date");
         assertFalse(res.getMetadata().isDestroyed(), "Secret destroyed when not expected");
         assertEquals(1, res.getMetadata().getVersion(), "Incorrect secret version");
+        assertNull(res.getMetadata().getCustomMetadata(), "Incorrect custom metadata");
 
         // Deleted KV v2 secret.
         res = assertDoesNotThrow(
@@ -127,6 +136,7 @@ class MetaSecretResponseTest extends AbstractModelTest<MetaSecretResponse> {
         assertNotNull(res.getMetadata().getDeletionTime(), "Incorrect deletion date");
         assertTrue(res.getMetadata().isDestroyed(), "Secret destroyed when not expected");
         assertEquals(2, res.getMetadata().getVersion(), "Incorrect secret version");
+        assertEquals(Map.of(CUSTOM_META_KEY, CUSTOM_META_VAL), res.getMetadata().getCustomMetadata(), "Incorrect custom metadata");
     }
 
     private void assertSecretData(SecretResponse res) {

--- a/src/test/java/de/stklcode/jvault/connector/model/response/MetadataResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/MetadataResponseTest.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import de.stklcode.jvault.connector.model.AbstractModelTest;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -35,11 +37,20 @@ class MetadataResponseTest extends AbstractModelTest<MetadataResponse> {
     private static final Integer CURRENT_VERSION = 3;
     private static final Integer MAX_VERSIONS = 0;
     private static final Integer OLDEST_VERSION = 1;
+    private static final Boolean CAS_REQUIRED = false;
+    private static final String CUSTOM_META_KEY = "test";
+    private static final String CUSTOM_META_VAL = "123";
+    private static final String DELETE_VERSION_AFTER = "0s";
 
     private static final String META_JSON = "{\n" +
             "  \"data\": {\n" +
+            "    \"cas_required\": " + CAS_REQUIRED + ",\n" +
             "    \"created_time\": \"" + V1_TIME + "\",\n" +
             "    \"current_version\": " + CURRENT_VERSION + ",\n" +
+            "    \"custom_metadata\": {" +
+            "      \"" + CUSTOM_META_KEY + "\": \"" + CUSTOM_META_VAL + "\"" +
+            "    },\n" +
+            "    \"delete_version_after\": \"" + DELETE_VERSION_AFTER + "\"," +
             "    \"max_versions\": " + MAX_VERSIONS + ",\n" +
             "    \"oldest_version\": " + OLDEST_VERSION + ",\n" +
             "    \"updated_time\": \"" + V3_TIME + "\",\n" +
@@ -88,11 +99,14 @@ class MetadataResponseTest extends AbstractModelTest<MetadataResponse> {
         );
         assertNotNull(res, "Parsed response is NULL");
         assertNotNull(res.getMetadata(), "Parsed metadata is NULL");
+        assertEquals(CAS_REQUIRED, res.getMetadata().isCasRequired(), "Incorrect CAS required flag");
         assertEquals(V1_TIME, res.getMetadata().getCreatedTimeString(), "Incorrect created time");
         assertNotNull(res.getMetadata().getCreatedTime(), "Parting created time failed");
         assertEquals(CURRENT_VERSION, res.getMetadata().getCurrentVersion(), "Incorrect current version");
         assertEquals(MAX_VERSIONS, res.getMetadata().getMaxVersions(), "Incorrect max versions");
         assertEquals(OLDEST_VERSION, res.getMetadata().getOldestVersion(), "Incorrect oldest version");
+        assertEquals(Map.of(CUSTOM_META_KEY, CUSTOM_META_VAL), res.getMetadata().getCustomMetadata(), "Incorrect custom metadata");
+        assertEquals(DELETE_VERSION_AFTER, res.getMetadata().getDeleteVersionAfter(), "Incorrect delete version after");
         assertEquals(V3_TIME, res.getMetadata().getUpdatedTimeString(), "Incorrect updated time");
         assertNotNull(res.getMetadata().getUpdatedTime(), "Parting updated time failed");
         assertEquals(3, res.getMetadata().getVersions().size(), "Incorrect number of versions");

--- a/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
@@ -55,6 +55,7 @@ class TokenResponseTest extends AbstractModelTest<TokenResponse> {
     private static final String TOKEN_ID = "my-token";
     private static final String TOKEN_ISSUE_TIME = "2018-04-17T11:35:54.466476078-04:00";
     private static final String TOKEN_TYPE = "service";
+    private static final String MOUNT_TYPE = "token";
 
     private static final String RES_JSON = "{\n" +
             "  \"lease_id\": \"\",\n" +
@@ -85,7 +86,8 @@ class TokenResponseTest extends AbstractModelTest<TokenResponse> {
             "    \"type\": \"" + TOKEN_TYPE + "\"\n" +
             "  },\n" +
             "  \"warnings\": null,\n" +
-            "  \"auth\": null\n" +
+            "  \"auth\": null,\n" +
+            "  \"mount_type\": \"" + MOUNT_TYPE + "\"\n" +
             "}";
 
     TokenResponseTest() {
@@ -125,6 +127,7 @@ class TokenResponseTest extends AbstractModelTest<TokenResponse> {
         assertEquals(RES_LEASE_DURATION, res.getLeaseDuration(), "Incorrect lease duration");
         assertEquals(RES_RENEWABLE, res.isRenewable(), "Incorrect response renewable flag");
         assertEquals(RES_LEASE_DURATION, res.getLeaseDuration(), "Incorrect response lease duration");
+        assertEquals(MOUNT_TYPE, res.getMountType(), "Incorrect mount type");
         // Extract token data.
         TokenData data = res.getData();
         assertNotNull(data, "Token data is NULL");


### PR DESCRIPTION
* HealthResponse
  *  `echo_duration_ms`
  * `clock_skew_ms`
  * `replication_primary_canary_age_ms`
  * `enterprise`
*  `AuthData`
  * `num_uses`
* All responses
  *  `mount_type`
  * `auth` (replaces subclass fields)
* `SecretMetadata`
  * `custom_metadata`
  * `cas_required` 
  * `delete_version_after`
* `AppRole`
  *  `enable_local_secret_id` renamed to `local_secret_ids`