### PR TITLE
build: remove Automatic-Module-Name from JAR manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Dependencies
 * Updated Jackson to 2.17.2
 
+### Fix
+* Remove `Automatic-Module-Name` from JAR manifest (#79)
+
 
 ## 1.3.0 (2024-06-29)
 

--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.4.2</version>
-                    <configuration>
-                        <archive>
-                            <manifestEntries>
-                                <Automatic-Module-Name>de.stklcode.jvault.connector</Automatic-Module-Name>
-                            </manifestEntries>
-                        </archive>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
We do provide a module-info already, so we should remove ths artifact from the Java 8 days.