### PR TITLE
fix: add jackson annotation module dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Remove deprecated `get...TimeString()` on model classes (#77)
 * Drop support fpr deprecated `App-ID` auth backend (#61) (#78)
 
+### Fix
+* Add jackson-annotations requirement to module-info (#84)
+
 ### Dependencies
 * Updated Jackson to 2.18.1 (#83)
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module de.stklcode.jvault.connector {
     opens de.stklcode.jvault.connector.model.response.embedded to com.fasterxml.jackson.databind;
 
     requires java.net.http;
+    requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.datatype.jsr310;
 }


### PR DESCRIPTION
Should fix the following error during JDK 11 compilation:

> Error:    (package com.fasterxml.jackson.annotation is declared in module com.fasterxml.jackson.annotation, but module de.stklcode.jvault.connector does not read it)
