### PR TITLE
deprecate default methods to read specific database credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+### Deprecations
+* `read...Credentials()` methods for specific database mounts (#92)
+
 ### Dependencies
 * Updated Jackson to 2.18.3 (#90)
 

--- a/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
@@ -681,7 +681,9 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @return the credentials response
      * @throws VaultConnectorException on error
      * @since 0.5.0
+     * @deprecated use {@link #readDbCredentials(String, String)} your MySQL mountpoint
      */
+    @Deprecated(since = "1.5.0", forRemoval = true)
     default CredentialsResponse readMySqlCredentials(final String role) throws VaultConnectorException {
         return readDbCredentials(role, "mysql");
     }
@@ -693,7 +695,9 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @return the credentials response
      * @throws VaultConnectorException on error
      * @since 0.5.0
+     * @deprecated use {@link #readDbCredentials(String, String)} your PostgreSQL mountpoint
      */
+    @Deprecated(since = "1.5.0", forRemoval = true)
     default CredentialsResponse readPostgreSqlCredentials(final String role) throws VaultConnectorException {
         return readDbCredentials(role, "postgresql");
     }
@@ -705,28 +709,32 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @return the credentials response
      * @throws VaultConnectorException on error
      * @since 0.5.0
+     * @deprecated use {@link #readDbCredentials(String, String)} your MSSQL mountpoint
      */
+    @Deprecated(since = "1.5.0", forRemoval = true)
     default CredentialsResponse readMsSqlCredentials(final String role) throws VaultConnectorException {
         return readDbCredentials(role, "mssql");
     }
 
     /**
-     * Read credentials for MSSQL backend at default mount point.
+     * Read credentials for MongoDB backend at default mount point.
      *
      * @param role the role name
      * @return the credentials response
      * @throws VaultConnectorException on error
      * @since 0.5.0
+     * @deprecated use {@link #readDbCredentials(String, String)} your MongoDB mountpoint
      */
+    @Deprecated(since = "1.5.0", forRemoval = true)
     default CredentialsResponse readMongoDbCredentials(final String role) throws VaultConnectorException {
         return readDbCredentials(role, "mongodb");
     }
 
     /**
-     * Read credentials for SQL backends.
+     * Read credentials for database backends.
      *
      * @param role  the role name
-     * @param mount mount point of the SQL backend
+     * @param mount mount point of the database backend
      * @return the credentials response
      * @throws VaultConnectorException on error
      * @since 0.5.0


### PR DESCRIPTION
The interface has some methods to read database credentials from specific mountpoints like "mysql". While ann database mounts share the same credential endpoints, the mount point itself can have any name. Let's clean up some methods of low benefit and deprecate the convenience methods.

Trivial replacement is `getDbCredentials()` with explicit mount point, if it's actually mounted on that path.