### PR TITLE
feat: support PEM certificate string from VAULT_CACERT env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Deprecations
 * `read...Credentials()` methods for specific database mounts (#92)
 
+### Features
+* Support PEM certificate string from `VAULT_CACERT` environment variable (#93)
+
 ### Dependencies
 * Updated Jackson to 2.18.3 (#90)
 


### PR DESCRIPTION
Vault CLI and the connector up to 1.4 support providing a path to a CA certificate file. Introduce support for providing PEM encoded content directly which might be convenient in container environments to provide a certificate e.g. from secrets without mounting it to some path.