### PR TITLE
replace deprecated java.net.URL usage with java.net.URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Support Vault transit API (#89)
 * Support PEM certificate string from `VAULT_CACERT` environment variable (#93)
 
+### Improvements
+* Replace deprecated `java.net.URL` usage with `java.net.URI` (#94)
+
 ### Dependencies
 * Updated Jackson to 2.18.3 (#90)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Improvements
 * Replace deprecated `java.net.URL` usage with `java.net.URI` (#94)
 
+### Fix
+* Fix initialization from environment without explicit port
+
 ### Dependencies
 * Updated Jackson to 2.18.3 (#90)
 

--- a/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilder.java
+++ b/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilder.java
@@ -22,10 +22,8 @@ import de.stklcode.jvault.connector.exception.VaultConnectorException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -305,11 +303,11 @@ public final class HTTPVaultConnectorBuilder {
         /* Parse URL from environment variable */
         if (System.getenv(ENV_VAULT_ADDR) != null && !System.getenv(ENV_VAULT_ADDR).isBlank()) {
             try {
-                var url = new URL(System.getenv(ENV_VAULT_ADDR));
-                this.host = url.getHost();
-                this.port = url.getPort();
-                this.tls = url.getProtocol().equals("https");
-            } catch (MalformedURLException e) {
+                var uri = new URI(System.getenv(ENV_VAULT_ADDR));
+                this.host = uri.getHost();
+                this.port = uri.getPort();
+                this.tls = uri.getScheme().equalsIgnoreCase("https");
+            } catch (URISyntaxException e) {
                 throw new ConnectionException("URL provided in environment variable malformed", e);
             }
         }

--- a/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilderTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorBuilderTest.java
@@ -41,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class HTTPVaultConnectorBuilderTest {
     private static final String VAULT_ADDR = "https://localhost:8201";
+    private static final String VAULT_ADDR_2 = "http://localhost";
+    private static final String VAULT_ADDR_3 = "https://localhost/vault/";
     private static final Integer VAULT_MAX_RETRIES = 13;
     private static final String VAULT_TOKEN = "00001111-2222-3333-4444-555566667777";
 
@@ -113,6 +115,22 @@ class HTTPVaultConnectorBuilderTest {
             assertNull(getRequestHelperPrivate(connector, "trustedCaCert"), "Trusted CA cert set when no cert provided");
             assertEquals(0, getRequestHelperPrivate(connector, "retries"), "Non-default number of retries, when none set");
 
+            return null;
+        });
+        withVaultEnv(VAULT_ADDR_2, null, null, null).execute(() -> {
+            HTTPVaultConnectorBuilder builder = assertDoesNotThrow(
+                    () -> HTTPVaultConnector.builder().fromEnv(),
+                    "Factory creation from minimal environment failed"
+            );
+            assertEquals(VAULT_ADDR_2 + "/v1/", getRequestHelperPrivate(builder.build(), "baseURL"), "URL without port not set correctly");
+            return null;
+        });
+        withVaultEnv(VAULT_ADDR_3, null, null, null).execute(() -> {
+            HTTPVaultConnectorBuilder builder = assertDoesNotThrow(
+                    () -> HTTPVaultConnector.builder().fromEnv(),
+                    "Factory creation from minimal environment failed"
+            );
+            assertEquals(VAULT_ADDR_3, getRequestHelperPrivate(builder.build(), "baseURL"), "URL with custom path not set correctly");
             return null;
         });
 


### PR DESCRIPTION
Deprecated in Java 20. Migrate URL parsing to backward compatible URI.