### PR TITLE
refactor: use builder to instantiate ObjectMapper

### DIFF
--- a/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
+++ b/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
@@ -2,8 +2,8 @@ package de.stklcode.jvault.connector.internal;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.stklcode.jvault.connector.exception.*;
 import de.stklcode.jvault.connector.model.response.ErrorResponse;
@@ -44,7 +44,7 @@ public final class RequestHelper implements Serializable {
     private final int retries;                      // Number of retries on 5xx errors.
     private final String tlsVersion;                // TLS version (#22).
     private final X509Certificate trustedCaCert;    // Trusted CA certificate.
-    private final ObjectMapper jsonMapper;
+    private final JsonMapper jsonMapper;
 
     /**
      * Constructor of the request helper.
@@ -65,10 +65,11 @@ public final class RequestHelper implements Serializable {
         this.timeout = timeout;
         this.tlsVersion = tlsVersion;
         this.trustedCaCert = trustedCaCert;
-        this.jsonMapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
+        this.jsonMapper = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
             .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+            .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+            .build();
     }
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/model/response/SecretResponse.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/SecretResponse.java
@@ -18,8 +18,8 @@ package de.stklcode.jvault.connector.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.stklcode.jvault.connector.exception.InvalidResponseException;
 import de.stklcode.jvault.connector.model.response.embedded.VersionMetadata;
@@ -85,10 +85,11 @@ public abstract class SecretResponse extends VaultDataResponse {
             } else if (type.isInstance(rawValue)) {
                 return type.cast(rawValue);
             } else {
-                var om = new ObjectMapper()
-                    .registerModule(new JavaTimeModule())
+                var om = JsonMapper.builder()
+                    .addModule(new JavaTimeModule())
                     .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                    .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+                    .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                    .build();
 
                 if (rawValue instanceof String) {
                     return om.readValue((String) rawValue, type);

--- a/src/test/java/de/stklcode/jvault/connector/model/AbstractModelTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AbstractModelTest.java
@@ -3,6 +3,7 @@ package de.stklcode.jvault.connector.model;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
@@ -29,10 +30,11 @@ public abstract class AbstractModelTest<T> {
      */
     protected AbstractModelTest(Class<T> modelClass) {
         this.modelClass = modelClass;
-        this.objectMapper = new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        this.objectMapper = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+            .build();
     }
 
     /**


### PR DESCRIPTION
Instead of applying configuration to a new ObjectMapper instance we use the JsonMapper builder pattern to create our mapper.

The resulting mappers are not yet fully immutable, but the old way will be removed in Jackson 3.0.