### PR TITLE
fix: use `Long` for numeric TTL fields (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Dependencies
 * Updated Jackson to 2.19.1 (#101)
 
+### Fix
+* Use `Long` for numeric TTL fields (#103) (#104)
+
 ### Test
 * Tested against Vault 1.2 to 1.20 (#102)
 

--- a/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/AppRole.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class AppRole implements Serializable {
-    private static final long serialVersionUID = 693228837510483448L;
+    private static final long serialVersionUID = 1546673231280751679L;
 
     @JsonProperty("role_name")
     private String name;
@@ -53,7 +53,7 @@ public final class AppRole implements Serializable {
 
     @JsonProperty("secret_id_ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Integer secretIdTtl;
+    private Long secretIdTtl;
 
     @JsonProperty("local_secret_ids")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -61,11 +61,11 @@ public final class AppRole implements Serializable {
 
     @JsonProperty("token_ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Integer tokenTtl;
+    private Long tokenTtl;
 
     @JsonProperty("token_max_ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Integer tokenMaxTtl;
+    private Long tokenMaxTtl;
 
     private List<String> tokenPolicies;
 
@@ -75,7 +75,7 @@ public final class AppRole implements Serializable {
 
     @JsonProperty("token_explicit_max_ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Integer tokenExplicitMaxTtl;
+    private Long tokenExplicitMaxTtl;
 
     @JsonProperty("token_no_default_policy")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -255,7 +255,7 @@ public final class AppRole implements Serializable {
     /**
      * @return maximum TTL in seconds for secrets
      */
-    public Integer getSecretIdTtl() {
+    public Long getSecretIdTtl() {
         return secretIdTtl;
     }
 
@@ -271,14 +271,14 @@ public final class AppRole implements Serializable {
     /**
      * @return token TTL in seconds
      */
-    public Integer getTokenTtl() {
+    public Long getTokenTtl() {
         return tokenTtl;
     }
 
     /**
      * @return maximum token TTL in seconds, including renewals
      */
-    public Integer getTokenMaxTtl() {
+    public Long getTokenMaxTtl() {
         return tokenMaxTtl;
     }
 
@@ -286,7 +286,7 @@ public final class AppRole implements Serializable {
      * @return explicit maximum token TTL in seconds, including renewals
      * @since 0.9
      */
-    public Integer getTokenExplicitMaxTtl() {
+    public Long getTokenExplicitMaxTtl() {
         return tokenExplicitMaxTtl;
     }
 
@@ -370,12 +370,12 @@ public final class AppRole implements Serializable {
         private List<String> secretIdBoundCidrs;
         private List<String> tokenPolicies;
         private Integer secretIdNumUses;
-        private Integer secretIdTtl;
+        private Long secretIdTtl;
         private Boolean localSecretIds;
-        private Integer tokenTtl;
-        private Integer tokenMaxTtl;
+        private Long tokenTtl;
+        private Long tokenMaxTtl;
         private List<String> tokenBoundCidrs;
-        private Integer tokenExplicitMaxTtl;
+        private Long tokenExplicitMaxTtl;
         private Boolean tokenNoDefaultPolicy;
         private Integer tokenNumUses;
         private Integer tokenPeriod;
@@ -520,7 +520,7 @@ public final class AppRole implements Serializable {
          * @param secretIdTtl the TTL
          * @return self
          */
-        public Builder withSecretIdTtl(final Integer secretIdTtl) {
+        public Builder withSecretIdTtl(final Long secretIdTtl) {
             this.secretIdTtl = secretIdTtl;
             return this;
         }
@@ -544,7 +544,7 @@ public final class AppRole implements Serializable {
          * @param tokenTtl the TTL
          * @return self
          */
-        public Builder withTokenTtl(final Integer tokenTtl) {
+        public Builder withTokenTtl(final Long tokenTtl) {
             this.tokenTtl = tokenTtl;
             return this;
         }
@@ -555,7 +555,7 @@ public final class AppRole implements Serializable {
          * @param tokenMaxTtl the TTL
          * @return self
          */
-        public Builder withTokenMaxTtl(final Integer tokenMaxTtl) {
+        public Builder withTokenMaxTtl(final Long tokenMaxTtl) {
             this.tokenMaxTtl = tokenMaxTtl;
             return this;
         }
@@ -596,7 +596,7 @@ public final class AppRole implements Serializable {
          * @param tokenExplicitMaxTtl the TTL
          * @return self
          */
-        public Builder withTokenExplicitMaxTtl(final Integer tokenExplicitMaxTtl) {
+        public Builder withTokenExplicitMaxTtl(final Long tokenExplicitMaxTtl) {
             this.tokenExplicitMaxTtl = tokenExplicitMaxTtl;
             return this;
         }

--- a/src/main/java/de/stklcode/jvault/connector/model/Token.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/Token.java
@@ -32,7 +32,7 @@ import java.util.*;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class Token implements Serializable {
-    private static final long serialVersionUID = 5208508683665365287L;
+    private static final long serialVersionUID = 7003016071684507115L;
 
     @JsonProperty("id")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -56,11 +56,11 @@ public final class Token implements Serializable {
 
     @JsonProperty("ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Integer ttl;
+    private Long ttl;
 
     @JsonProperty("explicit_max_ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Integer explicitMaxTtl;
+    private Long explicitMaxTtl;
 
     @JsonProperty("num_uses")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -162,7 +162,7 @@ public final class Token implements Serializable {
     /**
      * @return Time-to-live in seconds
      */
-    public Integer getTtl() {
+    public Long getTtl() {
         return ttl;
     }
 
@@ -170,7 +170,7 @@ public final class Token implements Serializable {
      * @return Explicit maximum time-to-live in seconds
      * @since 0.9
      */
-    public Integer getExplicitMaxTtl() {
+    public Long getExplicitMaxTtl() {
         return explicitMaxTtl;
     }
 
@@ -282,8 +282,8 @@ public final class Token implements Serializable {
         private String displayName;
         private Boolean noParent;
         private Boolean noDefaultPolicy;
-        private Integer ttl;
-        private Integer explicitMaxTtl;
+        private Long ttl;
+        private Long explicitMaxTtl;
         private Integer numUses;
         private List<String> policies;
         private Map<String, String> meta;
@@ -331,7 +331,7 @@ public final class Token implements Serializable {
          * @param ttl the ttl
          * @return self
          */
-        public Builder withTtl(final Integer ttl) {
+        public Builder withTtl(final Long ttl) {
             this.ttl = ttl;
             return this;
         }
@@ -342,7 +342,7 @@ public final class Token implements Serializable {
          * @param explicitMaxTtl the explicit max. TTL
          * @return self
          */
-        public Builder withExplicitMaxTtl(final Integer explicitMaxTtl) {
+        public Builder withExplicitMaxTtl(final Long explicitMaxTtl) {
             this.explicitMaxTtl = explicitMaxTtl;
             return this;
         }

--- a/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/TokenRole.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TokenRole implements Serializable {
-    private static final long serialVersionUID = -3505215215838576321L;
+    private static final long serialVersionUID = -4856948364869438439L;
 
     @JsonProperty("name")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -78,7 +78,7 @@ public final class TokenRole implements Serializable {
 
     @JsonProperty("token_explicit_max_ttl")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Integer tokenExplicitMaxTtl;
+    private Long tokenExplicitMaxTtl;
 
     @JsonProperty("token_no_default_policy")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -204,7 +204,7 @@ public final class TokenRole implements Serializable {
     /**
      * @return Token explicit maximum TTL
      */
-    public Integer getTokenExplicitMaxTtl() {
+    public Long getTokenExplicitMaxTtl() {
         return tokenExplicitMaxTtl;
     }
 
@@ -285,7 +285,7 @@ public final class TokenRole implements Serializable {
         private String pathSuffix;
         private List<String> allowedEntityAliases;
         private List<String> tokenBoundCidrs;
-        private Integer tokenExplicitMaxTtl;
+        private Long tokenExplicitMaxTtl;
         private Boolean tokenNoDefaultPolicy;
         private Integer tokenNumUses;
         private Integer tokenPeriod;
@@ -537,7 +537,7 @@ public final class TokenRole implements Serializable {
          * @param tokenExplicitMaxTtl explicit maximum TTL
          * @return self
          */
-        public Builder withTokenExplicitMaxTtl(final Integer tokenExplicitMaxTtl) {
+        public Builder withTokenExplicitMaxTtl(final Long tokenExplicitMaxTtl) {
             this.tokenExplicitMaxTtl = tokenExplicitMaxTtl;
             return this;
         }

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MountConfig.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/MountConfig.java
@@ -15,13 +15,13 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MountConfig implements Serializable {
-    private static final long serialVersionUID = -8653909672663717792L;
+    private static final long serialVersionUID = 7241631159224756605L;
 
     @JsonProperty("default_lease_ttl")
-    private Integer defaultLeaseTtl;
+    private Long defaultLeaseTtl;
 
     @JsonProperty("max_lease_ttl")
-    private Integer maxLeaseTtl;
+    private Long maxLeaseTtl;
 
     @JsonProperty("force_no_cache")
     private Boolean forceNoCache;
@@ -56,14 +56,14 @@ public class MountConfig implements Serializable {
     /**
      * @return Default lease TTL
      */
-    public Integer getDefaultLeaseTtl() {
+    public Long getDefaultLeaseTtl() {
         return defaultLeaseTtl;
     }
 
     /**
      * @return Maximum lease TTL
      */
-    public Integer getMaxLeaseTtl() {
+    public Long getMaxLeaseTtl() {
         return maxLeaseTtl;
     }
 

--- a/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
+++ b/src/main/java/de/stklcode/jvault/connector/model/response/embedded/TokenData.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TokenData implements Serializable {
-    private static final long serialVersionUID = -5749716740973138916L;
+    private static final long serialVersionUID = -4168046151053509784L;
 
     @JsonProperty("accessor")
     private String accessor;
@@ -43,7 +43,7 @@ public final class TokenData implements Serializable {
     private Integer creationTime;
 
     @JsonProperty("creation_ttl")
-    private Integer creationTtl;
+    private Long creationTtl;
 
     @JsonProperty("display_name")
     private String name;
@@ -55,7 +55,7 @@ public final class TokenData implements Serializable {
     private ZonedDateTime expireTime;
 
     @JsonProperty("explicit_max_ttl")
-    private Integer explicitMaxTtl;
+    private Long explicitMaxTtl;
 
     @JsonProperty("id")
     private String id;
@@ -82,7 +82,7 @@ public final class TokenData implements Serializable {
     private boolean renewable;
 
     @JsonProperty("ttl")
-    private Integer ttl;
+    private Long ttl;
 
     @JsonProperty("type")
     private String type;
@@ -104,7 +104,7 @@ public final class TokenData implements Serializable {
     /**
      * @return Creation TTL (in seconds)
      */
-    public Integer getCreationTtl() {
+    public Long getCreationTtl() {
         return creationTtl;
     }
 
@@ -135,7 +135,7 @@ public final class TokenData implements Serializable {
      * @return Explicit maximum TTL
      * @since 0.9
      */
-    public Integer getExplicitMaxTtl() {
+    public Long getExplicitMaxTtl() {
         return explicitMaxTtl;
     }
 
@@ -202,7 +202,7 @@ public final class TokenData implements Serializable {
     /**
      * @return Token TTL (in seconds)
      */
-    public Integer getTtl() {
+    public Long getTtl() {
         return ttl;
     }
 

--- a/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorIT.java
+++ b/src/test/java/de/stklcode/jvault/connector/HTTPVaultConnectorIT.java
@@ -862,7 +862,7 @@ class HTTPVaultConnectorIT {
                     .withDefaultPolicy()
                     .withMeta("test", "success")
                     .withMeta("key", "value")
-                    .withTtl(1234)
+                    .withTtl(1234L)
                     .build();
             InvalidResponseException e = assertThrows(
                     InvalidResponseException.class,

--- a/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/AppRoleTest.java
@@ -42,11 +42,11 @@ class AppRoleTest extends AbstractModelTest<AppRole> {
     private static final String POLICY = "policy";
     private static final String POLICY_2 = "policy2";
     private static final Integer SECRET_ID_NUM_USES = 10;
-    private static final Integer SECRET_ID_TTL = 7200;
+    private static final Long SECRET_ID_TTL = 7200L;
     private static final Boolean LOCAL_SECRET_IDS = false;
-    private static final Integer TOKEN_TTL = 4800;
-    private static final Integer TOKEN_MAX_TTL = 9600;
-    private static final Integer TOKEN_EXPLICIT_MAX_TTL = 14400;
+    private static final Long TOKEN_TTL = 4800L;
+    private static final Long TOKEN_MAX_TTL = 9600L;
+    private static final Long TOKEN_EXPLICIT_MAX_TTL = 14400L;
     private static final Boolean TOKEN_NO_DEFAULT_POLICY = false;
     private static final Integer TOKEN_NUM_USES = 42;
     private static final Integer TOKEN_PERIOD = 1234;

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenRoleTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenRoleTest.java
@@ -59,7 +59,7 @@ class TokenRoleTest extends AbstractModelTest<TokenRole> {
     private static final String TOKEN_BOUND_CIDR_2 = "198.51.100.0/24";
     private static final String TOKEN_BOUND_CIDR_3 = "203.0.113.0/24";
     private static final List<String> TOKEN_BOUND_CIDRS = Arrays.asList(TOKEN_BOUND_CIDR_2, TOKEN_BOUND_CIDR_1);
-    private static final Integer TOKEN_EXPLICIT_MAX_TTL = 1234;
+    private static final Long TOKEN_EXPLICIT_MAX_TTL = 1234L;
     private static final Boolean TOKEN_NO_DEFAULT_POLICY = false;
     private static final Integer TOKEN_NUM_USES = 5;
     private static final Integer TOKEN_PERIOD = 2345;

--- a/src/test/java/de/stklcode/jvault/connector/model/TokenTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/TokenTest.java
@@ -35,8 +35,8 @@ class TokenTest extends AbstractModelTest<Token> {
     private static final String DISPLAY_NAME = "display-name";
     private static final Boolean NO_PARENT = false;
     private static final Boolean NO_DEFAULT_POLICY = false;
-    private static final Integer TTL = 123;
-    private static final Integer EXPLICIT_MAX_TTL = 456;
+    private static final Long TTL = 123L;
+    private static final Long EXPLICIT_MAX_TTL = 456L;
     private static final Integer NUM_USES = 4;
     private static final List<String> POLICIES = new ArrayList<>();
     private static final String POLICY = "policy";

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AppRoleResponseTest.java
@@ -32,9 +32,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 0.6.2
  */
 class AppRoleResponseTest extends AbstractModelTest<AppRoleResponse> {
-    private static final Integer ROLE_TOKEN_TTL = 1200;
-    private static final Integer ROLE_TOKEN_MAX_TTL = 1800;
-    private static final Integer ROLE_SECRET_TTL = 600;
+    private static final Long ROLE_TOKEN_TTL = 1200L;
+    private static final Long ROLE_TOKEN_MAX_TTL = 1800L;
+    private static final Long ROLE_SECRET_TTL = 600L;
     private static final Integer ROLE_SECRET_NUM_USES = 40;
     private static final String ROLE_POLICY = "default";
     private static final Integer ROLE_PERIOD = 0;

--- a/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/AuthMethodsResponseTest.java
@@ -45,9 +45,9 @@ class AuthMethodsResponseTest extends AbstractModelTest<AuthMethodsResponse> {
     private static final String TK_UUID = "32ea9681-6bd6-6cec-eec3-d11260ba9741";
     private static final String TK_ACCESSOR = "auth_token_ac0dd95a";
     private static final String TK_DESCR = "token based credentials";
-    private static final Integer TK_LEASE_TTL = 0;
+    private static final Long TK_LEASE_TTL = 0L;
     private static final Boolean TK_FORCE_NO_CACHE = false;
-    private static final Integer TK_MAX_LEASE_TTL = 0;
+    private static final Long TK_MAX_LEASE_TTL = 0L;
     private static final String TK_TOKEN_TYPE = "default-service";
     private static final String TK_RUNNING_PLUGIN_VERSION = "v1.15.3+builtin.vault";
 

--- a/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/TokenResponseTest.java
@@ -35,8 +35,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class TokenResponseTest extends AbstractModelTest<TokenResponse> {
     private static final Integer TOKEN_CREATION_TIME = 1457533232;
-    private static final Integer TOKEN_TTL = 2764800;
-    private static final Integer TOKEN_EXPLICIT_MAX_TTL = 0;
+    private static final Long TOKEN_TTL = 2764800L;
+    private static final Long TOKEN_EXPLICIT_MAX_TTL = 0L;
     private static final String TOKEN_DISPLAY_NAME = "token";
     private static final String TOKEN_META_KEY = "foo";
     private static final String TOKEN_META_VALUE = "bar";
@@ -47,7 +47,7 @@ class TokenResponseTest extends AbstractModelTest<TokenResponse> {
     private static final String TOKEN_POLICY_1 = "default";
     private static final String TOKEN_POLICY_2 = "web";
     private static final Boolean RES_RENEWABLE = false;
-    private static final Integer RES_TTL = 2591976;
+    private static final Long RES_TTL = 2591976L;
     private static final Integer RES_LEASE_DURATION = 0;
     private static final String TOKEN_ACCESSOR = "VKvzT2fKHFsZFUus9LyoXCvu";
     private static final String TOKEN_ENTITY_ID = "7d2e3179-f69b-450c-7179-ac8ee8bd8ca9";

--- a/src/test/java/de/stklcode/jvault/connector/model/response/embedded/MountConfigTest.java
+++ b/src/test/java/de/stklcode/jvault/connector/model/response/embedded/MountConfigTest.java
@@ -14,8 +14,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Stefan Kalscheuer
  */
 class MountConfigTest extends AbstractModelTest<MountConfig> {
-    private static final Integer DEFAULT_LEASE_TTL = 1800;
-    private static final Integer MAX_LEASE_TTL = 3600;
+    private static final Long DEFAULT_LEASE_TTL = 1800L;
+    private static final Long MAX_LEASE_TTL = 3600L;
     private static final Boolean FORCE_NO_CACHE = false;
     private static final String TOKEN_TYPE = "default-service";
     private static final String AUDIT_NON_HMAC_REQ_KEYS_1 = "req1";


### PR DESCRIPTION
Mapping these fields as `Integer` limits the possible maximum TTL value to roughly 68 years. This may or may not be a reasonable value, but is technically a valid number in the JSON response. Convert all TTL-related fields to `Long`, so we can map such values.

resolves #103