### PR TITLE
fix: prevent potential off-by-1 error in internal mapOf() helper (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Dependencies
 * Updated Jackson to 2.20.0 (#106)
 
+### Fix
+* Prevent potential off-by-1 error in internal `mapOf()` helper (#107)
 
 ## 1.5.2 (2025-07-16)
 

--- a/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
@@ -732,7 +732,7 @@ public class HTTPVaultConnector implements VaultConnector {
      */
     private static Map<String, Object> mapOf(Object... keyValues) {
         Map<String, Object> map = new HashMap<>(keyValues.length / 2, 1);
-        for (int i = 0; i < keyValues.length; i = i + 2) {
+        for (int i = 0; i < keyValues.length - 1; i = i + 2) {
             Object key = keyValues[i];
             Object val = keyValues[i + 1];
             if (key instanceof String && val != null) {


### PR DESCRIPTION
Calling `mapOf()` with an odd number of arguments results in an `IndexOutOfBoundsException`.

Checking the arguments and throwing a custom exception might be an option as well, but given this is some internal helper method, let's just do it like we already do in `mapOfStrings()` and fix the loop condition. This way we interpret an odd number of arguments as key without value and omit as as we do with nulls by design.