### PR TITLE
encode user-provided URL parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Improvements
 * Extract API paths into a utility class (#108)
+* Encode user-provided URL parts (#109)
 
 ### Fix
 * Prevent potential off-by-1 error in internal `mapOf()` helper (#107)

--- a/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
+++ b/src/main/java/de/stklcode/jvault/connector/internal/RequestHelper.java
@@ -25,6 +25,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
@@ -263,9 +264,9 @@ public final class RequestHelper implements Serializable {
 
         if (!payload.isEmpty()) {
             uriBuilder.append("?").append(
-                payload.entrySet().stream().map(par ->
-                    URLEncoder.encode(par.getKey(), UTF_8) + "=" + URLEncoder.encode(par.getValue(), UTF_8)
-                ).collect(Collectors.joining("&"))
+                payload.entrySet().stream()
+                    .map(par -> encode(par.getKey()) + "=" + encode(par.getValue()))
+                    .collect(Collectors.joining("&"))
             );
         }
 
@@ -305,6 +306,17 @@ public final class RequestHelper implements Serializable {
         } catch (IOException e) {
             throw new InvalidResponseException(Error.PARSE_RESPONSE, e);
         }
+    }
+
+    /**
+     * Encode URL part.
+     *
+     * @param part Path part to URL-encode and insert into the template
+     * @return Encoded URL part
+     * @since 1.5.3
+     */
+    public static String encode(final String part) {
+        return URLEncoder.encode(Objects.requireNonNullElse(part, ""), UTF_8);
     }
 
     /**

--- a/src/main/java/de/stklcode/jvault/connector/internal/VaultApiPath.java
+++ b/src/main/java/de/stklcode/jvault/connector/internal/VaultApiPath.java
@@ -40,8 +40,8 @@ public final class VaultApiPath {
     // Auth paths
     public static final String AUTH_TOKEN = AUTH + "/token";
     public static final String AUTH_USERPASS_LOGIN = AUTH + "/userpass/login/";
-    public static final String AUTH_APPROLE = AUTH + "/approle";
-    public static final String AUTH_APPROLE_ROLE = AUTH_APPROLE + "/role/%s%s";
+    public static final String AUTH_APPROLE = AUTH + "/approle/";
+    public static final String AUTH_APPROLE_ROLE = AUTH_APPROLE + "role/";
 
     // Token operations
     public static final String TOKEN_LOOKUP = "/lookup";
@@ -56,9 +56,6 @@ public final class VaultApiPath {
     public static final String SECRET_DELETE = "/delete/";
     public static final String SECRET_UNDELETE = "/undelete/";
     public static final String SECRET_DESTROY = "/destroy/";
-
-    // Generic paths
-    public static final String LOGIN = "/login";
 
     // Transit engine paths
     public static final String TRANSIT_ENCRYPT = TRANSIT + "/encrypt/";


### PR DESCRIPTION
In various methods we use user-provided values like role names or lease ids as parts of the API request path.

Apply URL encoding to these paths that are not expected to contain any path separators or query args.