### PR TITLE
remove deprecated methods to read specific DB credentials (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Breaking
 * Requires Java 17 or later (#100) (#111)
 
+### Removal
+* Remove deprecated `read...Credentials()` methods (#112)
+
 
 ## 1.5.3 (2025-09-09)
 

--- a/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
@@ -748,62 +748,6 @@ public interface VaultConnector extends AutoCloseable, Serializable {
     }
 
     /**
-     * Read credentials for MySQL backend at default mount point.
-     *
-     * @param role the role name
-     * @return the credentials response
-     * @throws VaultConnectorException on error
-     * @since 0.5.0
-     * @deprecated use {@link #readDbCredentials(String, String)} your MySQL mountpoint
-     */
-    @Deprecated(since = "1.5.0", forRemoval = true)
-    default CredentialsResponse readMySqlCredentials(final String role) throws VaultConnectorException {
-        return readDbCredentials(role, "mysql");
-    }
-
-    /**
-     * Read credentials for PostgreSQL backend at default mount point.
-     *
-     * @param role the role name
-     * @return the credentials response
-     * @throws VaultConnectorException on error
-     * @since 0.5.0
-     * @deprecated use {@link #readDbCredentials(String, String)} your PostgreSQL mountpoint
-     */
-    @Deprecated(since = "1.5.0", forRemoval = true)
-    default CredentialsResponse readPostgreSqlCredentials(final String role) throws VaultConnectorException {
-        return readDbCredentials(role, "postgresql");
-    }
-
-    /**
-     * Read credentials for MSSQL backend at default mount point.
-     *
-     * @param role the role name
-     * @return the credentials response
-     * @throws VaultConnectorException on error
-     * @since 0.5.0
-     * @deprecated use {@link #readDbCredentials(String, String)} your MSSQL mountpoint
-     */
-    @Deprecated(since = "1.5.0", forRemoval = true)
-    default CredentialsResponse readMsSqlCredentials(final String role) throws VaultConnectorException {
-        return readDbCredentials(role, "mssql");
-    }
-
-    /**
-     * Read credentials for MongoDB backend at default mount point.
-     *
-     * @param role the role name
-     * @return the credentials response
-     * @throws VaultConnectorException on error
-     * @since 0.5.0
-     * @deprecated use {@link #readDbCredentials(String, String)} your MongoDB mountpoint
-     */
-    @Deprecated(since = "1.5.0", forRemoval = true)
-    default CredentialsResponse readMongoDbCredentials(final String role) throws VaultConnectorException {
-        return readDbCredentials(role, "mongodb");
-    }
-
-    /**
      * Read credentials for database backends.
      *
      * @param role  the role name


### PR DESCRIPTION
These methods have been deprecated since 1.5.0 (#92) and can trivially be replaced by a simple `read()` call using the corresponding mount path.