### PR TITLE
split VaultConnector interface into clients per module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Breaking
 * Requires Java 17 or later (#100) (#111)
+* Modified interface structure
+
+### Improvements
+* Split client interface to group feature sets together (#113)
+
+  Use `connector.sys()`, `.kv2()`, `.token()`, `.appRole()` and `.transit()` to access respective feature sets.
+
 
 ### Removal
 * Remove deprecated `read...Credentials()` methods (#112)

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Token token = Token.builder()
                    .withDisplayName("new test token")
                    .withPolicies("pol1", "pol2")
                    .build();
-vault.createToken(token);
+vault.token().create(token);
 
 // Create AppRole credentials
-vault.createAppRole("testrole", policyList);
-AppRoleSecretResponse secret = vault.createAppRoleSecret("testrole");
+vault.appRole().create("testrole", policyList);
+AppRoleSecretResponse secret = vault.appRole().createSecret("testrole");
 ```
 
 ## Links

--- a/src/main/java/de/stklcode/jvault/connector/AppRoleClient.java
+++ b/src/main/java/de/stklcode/jvault/connector/AppRoleClient.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2016-2025 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector;
+
+import de.stklcode.jvault.connector.exception.VaultConnectorException;
+import de.stklcode.jvault.connector.model.AppRole;
+import de.stklcode.jvault.connector.model.AppRoleSecret;
+import de.stklcode.jvault.connector.model.response.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AppRole client interface.
+ * Provides methods to interact with Vault's AppRole API.
+ *
+ * @since 2.0.0 extracted from {@link VaultConnector}
+ */
+public interface AppRoleClient {
+
+    /**
+     * Register a new AppRole role from given metamodel.
+     *
+     * @param role The role
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    boolean create(final AppRole role) throws VaultConnectorException;
+
+    /**
+     * Register new AppRole role with default policy.
+     *
+     * @param roleName The role name
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    default boolean create(final String roleName) throws VaultConnectorException {
+        return create(roleName, new ArrayList<>());
+    }
+
+    /**
+     * Register new AppRole role with policies.
+     *
+     * @param roleName The role name
+     * @param policies The policies to associate with
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    default boolean create(final String roleName, final List<String> policies) throws VaultConnectorException {
+        return create(roleName, policies, null);
+    }
+
+    /**
+     * Register new AppRole role with default policy and custom ID.
+     *
+     * @param roleName The role name
+     * @param roleID   A custom role ID
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    default boolean create(final String roleName, final String roleID) throws VaultConnectorException {
+        return create(roleName, new ArrayList<>(), roleID);
+    }
+
+    /**
+     * Register new AppRole role with policies and custom ID.
+     *
+     * @param roleName The role name
+     * @param policies The policies to associate with
+     * @param roleID   A custom role ID
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    default boolean create(final String roleName, final List<String> policies, final String roleID)
+        throws VaultConnectorException {
+        return create(AppRole.builder(roleName).withTokenPolicies(policies).withId(roleID).build());
+    }
+
+    /**
+     * Delete AppRole role from Vault.
+     *
+     * @param roleName The role name
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     */
+    boolean delete(final String roleName) throws VaultConnectorException;
+
+    /**
+     * Lookup an AppRole role.
+     *
+     * @param roleName The role name
+     * @return Result of the lookup
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    AppRoleResponse lookup(final String roleName) throws VaultConnectorException;
+
+    /**
+     * Retrieve ID for an AppRole role.
+     *
+     * @param roleName The role name
+     * @return The role ID
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    String getRoleID(final String roleName) throws VaultConnectorException;
+
+    /**
+     * Set custom ID for an AppRole role.
+     *
+     * @param roleName The role name
+     * @param roleID   The role ID
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    boolean setRoleID(final String roleName, final String roleID) throws VaultConnectorException;
+
+    /**
+     * Register new random generated AppRole secret.
+     *
+     * @param roleName The role name
+     * @return The secret ID
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    default AppRoleSecretResponse createSecret(final String roleName) throws VaultConnectorException {
+        return createSecret(roleName, new AppRoleSecret());
+    }
+
+    /**
+     * Register new AppRole secret with custom ID.
+     *
+     * @param roleName The role name
+     * @param secretID A custom secret ID
+     * @return The secret ID
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    default AppRoleSecretResponse createSecret(final String roleName, final String secretID)
+        throws VaultConnectorException {
+        return createSecret(roleName, new AppRoleSecret(secretID));
+    }
+
+    /**
+     * Register new AppRole secret with custom ID.
+     *
+     * @param roleName The role name
+     * @param secret   The secret meta object
+     * @return The secret ID
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    AppRoleSecretResponse createSecret(final String roleName, final AppRoleSecret secret)
+        throws VaultConnectorException;
+
+    /**
+     * Lookup an AppRole secret.
+     *
+     * @param roleName The role name
+     * @param secretID The secret ID
+     * @return Result of the lookup
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    AppRoleSecretResponse lookupSecret(final String roleName, final String secretID)
+        throws VaultConnectorException;
+
+    /**
+     * Destroy an AppRole secret.
+     *
+     * @param roleName The role name
+     * @param secretID The secret meta object
+     * @return The secret ID
+     * @throws VaultConnectorException on error
+     * @since 0.4.0
+     */
+    boolean destroySecret(final String roleName, final String secretID) throws VaultConnectorException;
+
+    /**
+     * List existing (accessible) AppRole roles.
+     *
+     * @return List of roles
+     * @throws VaultConnectorException on error
+     */
+    List<String> listRoles() throws VaultConnectorException;
+
+    /**
+     * List existing (accessible) secret IDs for AppRole role.
+     *
+     * @param roleName The role name
+     * @return List of roles
+     * @throws VaultConnectorException on error
+     */
+    List<String> listSecrets(final String roleName) throws VaultConnectorException;
+}

--- a/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/HTTPVaultConnector.java
@@ -107,52 +107,8 @@ public class HTTPVaultConnector implements VaultConnector {
     }
 
     @Override
-    public final SealResponse sealStatus() throws VaultConnectorException {
-        return request.get(SYS_SEAL_STATUS, emptyMap(), token, SealResponse.class);
-    }
-
-    @Override
-    public final void seal() throws VaultConnectorException {
-        request.put(SYS_SEAL, emptyMap(), token);
-    }
-
-    @Override
-    public final SealResponse unseal(final String key, final Boolean reset) throws VaultConnectorException {
-        Map<String, String> param = mapOfStrings(
-            "key", key,
-            "reset", reset
-        );
-
-        return request.put(SYS_UNSEAL, param, token, SealResponse.class);
-    }
-
-    @Override
-    public HealthResponse getHealth() throws VaultConnectorException {
-
-        return request.get(
-            SYS_HEALTH,
-            // Force status code to be 200, so we don't need to modify the request sequence.
-            Map.of(
-                "standbycode", "200",   // Default: 429.
-                "sealedcode", "200",    // Default: 503.
-                "uninitcode", "200"     // Default: 501.
-            ),
-            token,
-            HealthResponse.class
-        );
-    }
-
-    @Override
     public final boolean isAuthorized() {
         return authorized && (tokenTTL == 0 || tokenTTL >= System.currentTimeMillis());
-    }
-
-    @Override
-    public final List<AuthBackend> getAuthBackends() throws VaultConnectorException {
-        /* Issue request and parse response */
-        AuthMethodsResponse amr = request.get(SYS_AUTH, emptyMap(), token, AuthMethodsResponse.class);
-
-        return amr.getSupportedMethods().values().stream().map(AuthMethod::getType).toList();
     }
 
     @Override
@@ -203,206 +159,10 @@ public class HTTPVaultConnector implements VaultConnector {
     }
 
     @Override
-    public final boolean createAppRole(final AppRole role) throws VaultConnectorException {
-        requireAuth();
-
-        /* Issue request and expect code 204 with empty response */
-        request.postWithoutResponse(AUTH_APPROLE_ROLE + encode(role.getName()), role, token);
-
-        /* Set custom ID if provided */
-        return !(role.getId() != null && !role.getId().isEmpty()) || setAppRoleID(role.getName(), role.getId());
-    }
-
-    @Override
-    public final AppRoleResponse lookupAppRole(final String roleName) throws VaultConnectorException {
-        requireAuth();
-        /* Request HTTP response and parse Secret */
-        return request.get(
-            AUTH_APPROLE_ROLE + encode(roleName),
-            emptyMap(),
-            token,
-            AppRoleResponse.class
-        );
-    }
-
-    @Override
-    public final boolean deleteAppRole(final String roleName) throws VaultConnectorException {
-        requireAuth();
-
-        /* Issue request and expect code 204 with empty response */
-        request.deleteWithoutResponse(AUTH_APPROLE_ROLE + encode(roleName), token);
-
-        return true;
-    }
-
-    @Override
-    public final String getAppRoleID(final String roleName) throws VaultConnectorException {
-        requireAuth();
-        /* Issue request, parse response and extract Role ID */
-        return request.get(
-            AUTH_APPROLE_ROLE + encode(roleName) + "/role-id",
-            emptyMap(),
-            token,
-            RawDataResponse.class
-        ).getData().get("role_id").toString();
-    }
-
-    @Override
-    public final boolean setAppRoleID(final String roleName, final String roleID) throws VaultConnectorException {
-        requireAuth();
-
-        /* Issue request and expect code 204 with empty response */
-        request.postWithoutResponse(
-            AUTH_APPROLE_ROLE + encode(roleName) + "/role-id",
-            singletonMap("role_id", roleID),
-            token
-        );
-
-        return true;
-    }
-
-    @Override
-    public final AppRoleSecretResponse createAppRoleSecret(final String roleName, final AppRoleSecret secret)
-        throws VaultConnectorException {
-        requireAuth();
-
-        if (secret.getId() != null && !secret.getId().isEmpty()) {
-            return request.post(
-                AUTH_APPROLE_ROLE + encode(roleName) + "/custom-secret-id",
-                secret,
-                token,
-                AppRoleSecretResponse.class
-            );
-        } else {
-            return request.post(
-                AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id",
-                secret, token,
-                AppRoleSecretResponse.class
-            );
-        }
-    }
-
-    @Override
-    public final AppRoleSecretResponse lookupAppRoleSecret(final String roleName, final String secretID)
-        throws VaultConnectorException {
-        requireAuth();
-
-        /* Issue request and parse secret response */
-        return request.post(
-            AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id/lookup",
-            new AppRoleSecret(secretID),
-            token,
-            AppRoleSecretResponse.class
-        );
-    }
-
-    @Override
-    public final boolean destroyAppRoleSecret(final String roleName, final String secretID)
-        throws VaultConnectorException {
-        requireAuth();
-
-        /* Issue request and expect code 204 with empty response */
-        request.postWithoutResponse(
-            AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id/destroy",
-            new AppRoleSecret(secretID),
-            token);
-
-        return true;
-    }
-
-    @Override
-    public final List<String> listAppRoles() throws VaultConnectorException {
-        requireAuth();
-
-        SecretListResponse secrets = request.get(
-            AUTH_APPROLE + "role?list=true",
-            emptyMap(),
-            token,
-            SecretListResponse.class
-        );
-
-        return secrets.getKeys();
-    }
-
-    @Override
-    public final List<String> listAppRoleSecrets(final String roleName) throws VaultConnectorException {
-        requireAuth();
-
-        SecretListResponse secrets = request.get(
-            AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id?list=true",
-            emptyMap(),
-            token,
-            SecretListResponse.class
-        );
-
-        return secrets.getKeys();
-    }
-
-    @Override
     public final SecretResponse read(final String key) throws VaultConnectorException {
         requireAuth();
         /* Issue request and parse secret response */
         return request.get(key, emptyMap(), token, PlainSecretResponse.class);
-    }
-
-    @Override
-    public final SecretResponse readSecretVersion(final String mount, final String key, final Integer version)
-        throws VaultConnectorException {
-        requireAuth();
-        /* Request HTTP response and parse secret metadata */
-        Map<String, String> args = mapOfStrings("version", version);
-
-        return request.get(mount + SECRET_DATA + key, args, token, MetaSecretResponse.class);
-    }
-
-    @Override
-    public final MetadataResponse readSecretMetadata(final String mount, final String key)
-        throws VaultConnectorException {
-        requireAuth();
-
-        /* Request HTTP response and parse secret metadata */
-        return request.get(mount + SECRET_METADATA + key, emptyMap(), token, MetadataResponse.class);
-    }
-
-    @Override
-    public void updateSecretMetadata(final String mount,
-                                     final String key,
-                                     final Integer maxVersions,
-                                     final boolean casRequired) throws VaultConnectorException {
-        requireAuth();
-
-        Map<String, Object> payload = mapOf(
-            "max_versions", maxVersions,
-            "cas_required", casRequired
-        );
-
-        write(mount + SECRET_METADATA + key, payload);
-    }
-
-    @Override
-    public final SecretVersionResponse writeSecretData(final String mount,
-                                                       final String key,
-                                                       final Map<String, Object> data,
-                                                       final Integer cas) throws VaultConnectorException {
-        requireAuth();
-
-        if (key == null || key.isEmpty()) {
-            throw new InvalidRequestException("Secret path must not be empty.");
-        }
-
-        // Add CAS value to options map if present.
-        Map<String, Object> options = mapOf("cas", cas);
-
-        /* Issue request and parse metadata response */
-        return request.post(
-            mount + SECRET_DATA + key,
-            Map.of(
-                "data", data,
-                "options", options
-            ),
-            token,
-            SecretVersionResponse.class
-        );
     }
 
     @Override
@@ -447,57 +207,6 @@ public class HTTPVaultConnector implements VaultConnector {
     }
 
     @Override
-    public final void deleteLatestSecretVersion(final String mount, final String key) throws VaultConnectorException {
-        delete(mount + SECRET_DATA + key);
-    }
-
-    @Override
-    public final void deleteAllSecretVersions(final String mount, final String key) throws VaultConnectorException {
-        delete(mount + SECRET_METADATA + key);
-    }
-
-    @Override
-    public final void deleteSecretVersions(final String mount, final String key, final int... versions)
-        throws VaultConnectorException {
-        handleSecretVersions(mount, SECRET_DELETE, key, versions);
-    }
-
-    @Override
-    public final void undeleteSecretVersions(final String mount, final String key, final int... versions)
-        throws VaultConnectorException {
-        handleSecretVersions(mount, SECRET_UNDELETE, key, versions);
-    }
-
-    @Override
-    public final void destroySecretVersions(final String mount, final String key, final int... versions)
-        throws VaultConnectorException {
-        handleSecretVersions(mount, SECRET_DESTROY, key, versions);
-    }
-
-    /**
-     * Common method to bundle secret version operations.
-     *
-     * @param mount    Secret store mount point (without leading or trailing slash).
-     * @param pathPart Path part to query.
-     * @param key      Secret key.
-     * @param versions Versions to handle.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    private void handleSecretVersions(final String mount,
-                                      final String pathPart,
-                                      final String key,
-                                      final int... versions) throws VaultConnectorException {
-        requireAuth();
-
-        /* Request HTTP response and expect empty result */
-        Map<String, Object> payload = singletonMap("versions", versions);
-
-        /* Issue request and expect code 204 with empty response */
-        request.postWithoutResponse(mount + pathPart + key, payload, token);
-    }
-
-    @Override
     public final void revoke(final String leaseID) throws VaultConnectorException {
         requireAuth();
 
@@ -519,21 +228,28 @@ public class HTTPVaultConnector implements VaultConnector {
     }
 
     @Override
-    public final AuthResponse createToken(final Token token) throws VaultConnectorException {
-        return createTokenInternal(token, AUTH_TOKEN + TOKEN_CREATE);
+    public KV2ClientImpl kv2() {
+        return new KV2ClientImpl();
     }
 
     @Override
-    public final AuthResponse createToken(final Token token, final boolean orphan) throws VaultConnectorException {
-        return createTokenInternal(token, AUTH_TOKEN + TOKEN_CREATE_ORPHAN);
+    public TokenClientImpl token() {
+        return new TokenClientImpl();
     }
 
     @Override
-    public final AuthResponse createToken(final Token token, final String role) throws VaultConnectorException {
-        if (role == null || role.isEmpty()) {
-            throw new InvalidRequestException("No role name specified.");
-        }
-        return createTokenInternal(token, AUTH_TOKEN + TOKEN_CREATE + "/" + encode(role));
+    public AppRoleClient appRole() {
+        return new AppRoleClientImpl();
+    }
+
+    @Override
+    public TransitClientImpl transit() {
+        return new TransitClientImpl();
+    }
+
+    @Override
+    public SysClientImpl sys() {
+        return new SysClientImpl();
     }
 
     @Override
@@ -541,124 +257,6 @@ public class HTTPVaultConnector implements VaultConnector {
         authorized = false;
         token = null;
         tokenTTL = 0;
-    }
-
-    /**
-     * Create token.
-     * Centralized method to handle different token creation requests.
-     *
-     * @param token the token
-     * @param path  request path
-     * @return the response
-     * @throws VaultConnectorException on error
-     */
-    private AuthResponse createTokenInternal(final Token token, final String path) throws VaultConnectorException {
-        requireAuth();
-
-        if (token == null) {
-            throw new InvalidRequestException("Token must be provided.");
-        }
-
-        return request.post(path, token, this.token, AuthResponse.class);
-    }
-
-    @Override
-    public final TokenResponse lookupToken(final String token) throws VaultConnectorException {
-        requireAuth();
-
-        /* Request HTTP response and parse Secret */
-        return request.get(
-            AUTH_TOKEN + TOKEN_LOOKUP,
-            singletonMap("token", token),
-            token,
-            TokenResponse.class
-        );
-    }
-
-    @Override
-    public boolean createOrUpdateTokenRole(final String name, final TokenRole role) throws VaultConnectorException {
-        requireAuth();
-
-        if (name == null) {
-            throw new InvalidRequestException("Role name must be provided.");
-        } else if (role == null) {
-            throw new InvalidRequestException("Role must be provided.");
-        }
-
-        // Issue request and expect code 204 with empty response.
-        request.postWithoutResponse(AUTH_TOKEN + TOKEN_ROLES + "/" + encode(name), role, token);
-
-        return true;
-    }
-
-    @Override
-    public TokenRoleResponse readTokenRole(final String name) throws VaultConnectorException {
-        requireAuth();
-
-        // Request HTTP response and parse response.
-        return request.get(AUTH_TOKEN + TOKEN_ROLES + "/" + encode(name), emptyMap(), token, TokenRoleResponse.class);
-    }
-
-    @Override
-    public List<String> listTokenRoles() throws VaultConnectorException {
-        requireAuth();
-
-        return list(AUTH_TOKEN + TOKEN_ROLES);
-    }
-
-    @Override
-    public boolean deleteTokenRole(final String name) throws VaultConnectorException {
-        requireAuth();
-
-        if (name == null) {
-            throw new InvalidRequestException("Role name must be provided.");
-        }
-
-        // Issue request and expect code 204 with empty response.
-        request.deleteWithoutResponse(AUTH_TOKEN + TOKEN_ROLES + "/" + encode(name), token);
-
-        return true;
-    }
-
-    @Override
-    public final TransitResponse transitEncrypt(final String keyName, final String plaintext)
-        throws VaultConnectorException {
-        requireAuth();
-
-        Map<String, Object> payload = mapOf(
-            "plaintext", plaintext
-        );
-
-        return request.post(TRANSIT_ENCRYPT + encode(keyName), payload, token, TransitResponse.class);
-    }
-
-    @Override
-    public final TransitResponse transitDecrypt(final String keyName, final String ciphertext)
-        throws VaultConnectorException {
-        requireAuth();
-
-        Map<String, Object> payload = mapOf(
-            "ciphertext", ciphertext
-        );
-
-        return request.post(TRANSIT_DECRYPT + encode(keyName), payload, token, TransitResponse.class);
-    }
-
-    @Override
-    public final TransitResponse transitHash(final String algorithm, final String input, final String format)
-        throws VaultConnectorException {
-        if (format != null && !"hex".equals(format) && !"base64".equals(format)) {
-            throw new IllegalArgumentException("Unsupported format " + format);
-        }
-
-        requireAuth();
-
-        Map<String, Object> payload = mapOf(
-            "input", input,
-            "format", format
-        );
-
-        return request.post(TRANSIT_HASH + encode(algorithm), payload, token, TransitResponse.class);
     }
 
     /**
@@ -709,5 +307,461 @@ public class HTTPVaultConnector implements VaultConnector {
         }
 
         return map;
+    }
+
+    /**
+     * Sub-client for KV v2 methods.
+     */
+    public class KV2ClientImpl implements KV2Client {
+        @Override
+        public final SecretResponse readVersion(final String mount, final String key, final Integer version)
+            throws VaultConnectorException {
+            requireAuth();
+            /* Request HTTP response and parse secret metadata */
+            Map<String, String> args = mapOfStrings("version", version);
+
+            return request.get(mount + SECRET_DATA + key, args, token, MetaSecretResponse.class);
+        }
+
+        @Override
+        public final MetadataResponse readMetadata(final String mount, final String key)
+            throws VaultConnectorException {
+            requireAuth();
+
+            /* Request HTTP response and parse secret metadata */
+            return request.get(mount + SECRET_METADATA + key, emptyMap(), token, MetadataResponse.class);
+        }
+
+        @Override
+        public void updateMetadata(final String mount,
+                                   final String key,
+                                   final Integer maxVersions,
+                                   final boolean casRequired) throws VaultConnectorException {
+            requireAuth();
+
+            Map<String, Object> payload = mapOf(
+                "max_versions", maxVersions,
+                "cas_required", casRequired
+            );
+
+            write(mount + SECRET_METADATA + key, payload);
+        }
+
+        @Override
+        public final SecretVersionResponse writeData(final String mount,
+                                                     final String key,
+                                                     final Map<String, Object> data,
+                                                     final Integer cas) throws VaultConnectorException {
+            requireAuth();
+
+            if (key == null || key.isEmpty()) {
+                throw new InvalidRequestException("Secret path must not be empty.");
+            }
+
+            // Add CAS value to options map if present.
+            Map<String, Object> options = mapOf("cas", cas);
+
+            /* Issue request and parse metadata response */
+            return request.post(
+                mount + SECRET_DATA + key,
+                Map.of(
+                    "data", data,
+                    "options", options
+                ),
+                token,
+                SecretVersionResponse.class
+            );
+        }
+
+        @Override
+        public final void deleteLatestVersion(final String mount, final String key) throws VaultConnectorException {
+            delete(mount + SECRET_DATA + key);
+        }
+
+        @Override
+        public final void deleteAllVersions(final String mount, final String key) throws VaultConnectorException {
+            delete(mount + SECRET_METADATA + key);
+        }
+
+        @Override
+        public final void deleteVersions(final String mount, final String key, final int... versions)
+            throws VaultConnectorException {
+            handleSecretVersions(mount, SECRET_DELETE, key, versions);
+        }
+
+        @Override
+        public final void undeleteVersions(final String mount, final String key, final int... versions)
+            throws VaultConnectorException {
+            handleSecretVersions(mount, SECRET_UNDELETE, key, versions);
+        }
+
+        @Override
+        public final void destroyVersions(final String mount, final String key, final int... versions)
+            throws VaultConnectorException {
+            handleSecretVersions(mount, SECRET_DESTROY, key, versions);
+        }
+
+        /**
+         * Common method to bundle secret version operations.
+         *
+         * @param mount    Secret store mount point (without leading or trailing slash).
+         * @param pathPart Path part to query.
+         * @param key      Secret key.
+         * @param versions Versions to handle.
+         * @throws VaultConnectorException on error
+         * @since 0.8
+         */
+        private void handleSecretVersions(final String mount,
+                                          final String pathPart,
+                                          final String key,
+                                          final int... versions) throws VaultConnectorException {
+            requireAuth();
+
+            /* Request HTTP response and expect empty result */
+            Map<String, Object> payload = singletonMap("versions", versions);
+
+            /* Issue request and expect code 204 with empty response */
+            request.postWithoutResponse(mount + pathPart + key, payload, token);
+        }
+    }
+
+    /**
+     * Sub-client for token methods.
+     */
+    public class TokenClientImpl implements TokenClient {
+
+        @Override
+        public final AuthResponse create(final Token token) throws VaultConnectorException {
+            return createInternal(token, AUTH_TOKEN + TOKEN_CREATE);
+        }
+
+        @Override
+        public final AuthResponse create(final Token token, final boolean orphan) throws VaultConnectorException {
+            return createInternal(token, AUTH_TOKEN + TOKEN_CREATE_ORPHAN);
+        }
+
+        @Override
+        public final AuthResponse create(final Token token, final String role) throws VaultConnectorException {
+            if (role == null || role.isEmpty()) {
+                throw new InvalidRequestException("No role name specified.");
+            }
+            return createInternal(token, AUTH_TOKEN + TOKEN_CREATE + "/" + encode(role));
+        }
+
+        /**
+         * Create token.
+         * Centralized method to handle different token creation requests.
+         *
+         * @param token the token
+         * @param path  request path
+         * @return the response
+         * @throws VaultConnectorException on error
+         */
+        private AuthResponse createInternal(final Token token, final String path) throws VaultConnectorException {
+            requireAuth();
+
+            if (token == null) {
+                throw new InvalidRequestException("Token must be provided.");
+            }
+
+            return request.post(path, token, HTTPVaultConnector.this.token, AuthResponse.class);
+        }
+
+        @Override
+        public final TokenResponse lookup(final String token) throws VaultConnectorException {
+            requireAuth();
+
+            /* Request HTTP response and parse Secret */
+            return request.get(
+                AUTH_TOKEN + TOKEN_LOOKUP,
+                singletonMap("token", token),
+                token,
+                TokenResponse.class
+            );
+        }
+
+        @Override
+        public boolean createOrUpdateRole(final String name, final TokenRole role) throws VaultConnectorException {
+            requireAuth();
+
+            if (name == null) {
+                throw new InvalidRequestException("Role name must be provided.");
+            } else if (role == null) {
+                throw new InvalidRequestException("Role must be provided.");
+            }
+
+            // Issue request and expect code 204 with empty response.
+            request.postWithoutResponse(AUTH_TOKEN + TOKEN_ROLES + "/" + encode(name), role, token);
+
+            return true;
+        }
+
+        @Override
+        public TokenRoleResponse readRole(final String name) throws VaultConnectorException {
+            requireAuth();
+
+            // Request HTTP response and parse response.
+            return request.get(AUTH_TOKEN + TOKEN_ROLES + "/" + encode(name), emptyMap(), token, TokenRoleResponse.class);
+        }
+
+        @Override
+        public List<String> listRoles() throws VaultConnectorException {
+            requireAuth();
+
+            return list(AUTH_TOKEN + TOKEN_ROLES);
+        }
+
+        @Override
+        public boolean deleteRole(final String name) throws VaultConnectorException {
+            requireAuth();
+
+            if (name == null) {
+                throw new InvalidRequestException("Role name must be provided.");
+            }
+
+            // Issue request and expect code 204 with empty response.
+            request.deleteWithoutResponse(AUTH_TOKEN + TOKEN_ROLES + "/" + encode(name), token);
+
+            return true;
+        }
+    }
+
+    /**
+     * Sub-client for AppRole methods.
+     */
+    public class AppRoleClientImpl implements AppRoleClient {
+
+        @Override
+        public final boolean create(final AppRole role) throws VaultConnectorException {
+            requireAuth();
+
+            /* Issue request and expect code 204 with empty response */
+            request.postWithoutResponse(AUTH_APPROLE_ROLE + encode(role.getName()), role, token);
+
+            /* Set custom ID if provided */
+            return !(role.getId() != null && !role.getId().isEmpty()) || setRoleID(role.getName(), role.getId());
+        }
+
+        @Override
+        public final AppRoleResponse lookup(final String roleName) throws VaultConnectorException {
+            requireAuth();
+            /* Request HTTP response and parse Secret */
+            return request.get(
+                AUTH_APPROLE_ROLE + encode(roleName),
+                emptyMap(),
+                token,
+                AppRoleResponse.class
+            );
+        }
+
+        @Override
+        public final boolean delete(final String roleName) throws VaultConnectorException {
+            requireAuth();
+
+            /* Issue request and expect code 204 with empty response */
+            request.deleteWithoutResponse(AUTH_APPROLE_ROLE + encode(roleName), token);
+
+            return true;
+        }
+
+        @Override
+        public final String getRoleID(final String roleName) throws VaultConnectorException {
+            requireAuth();
+            /* Issue request, parse response and extract Role ID */
+            return request.get(
+                AUTH_APPROLE_ROLE + encode(roleName) + "/role-id",
+                emptyMap(),
+                token,
+                RawDataResponse.class
+            ).getData().get("role_id").toString();
+        }
+
+        @Override
+        public final boolean setRoleID(final String roleName, final String roleID) throws VaultConnectorException {
+            requireAuth();
+
+            /* Issue request and expect code 204 with empty response */
+            request.postWithoutResponse(
+                AUTH_APPROLE_ROLE + encode(roleName) + "/role-id",
+                singletonMap("role_id", roleID),
+                token
+            );
+
+            return true;
+        }
+
+        @Override
+        public final AppRoleSecretResponse createSecret(final String roleName, final AppRoleSecret secret)
+            throws VaultConnectorException {
+            requireAuth();
+
+            if (secret.getId() != null && !secret.getId().isEmpty()) {
+                return request.post(
+                    AUTH_APPROLE_ROLE + encode(roleName) + "/custom-secret-id",
+                    secret,
+                    token,
+                    AppRoleSecretResponse.class
+                );
+            } else {
+                return request.post(
+                    AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id",
+                    secret,
+                    token,
+                    AppRoleSecretResponse.class
+                );
+            }
+        }
+
+        @Override
+        public final AppRoleSecretResponse lookupSecret(final String roleName, final String secretID)
+            throws VaultConnectorException {
+            requireAuth();
+
+            /* Issue request and parse secret response */
+            return request.post(
+                AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id/lookup",
+                new AppRoleSecret(secretID),
+                token,
+                AppRoleSecretResponse.class
+            );
+        }
+
+        @Override
+        public final boolean destroySecret(final String roleName, final String secretID)
+            throws VaultConnectorException {
+            requireAuth();
+
+            /* Issue request and expect code 204 with empty response */
+            request.postWithoutResponse(
+                AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id/destroy",
+                new AppRoleSecret(secretID),
+                token);
+
+            return true;
+        }
+
+        @Override
+        public final List<String> listRoles() throws VaultConnectorException {
+            requireAuth();
+
+            SecretListResponse secrets = request.get(
+                AUTH_APPROLE + "role?list=true",
+                emptyMap(),
+                token,
+                SecretListResponse.class
+            );
+
+            return secrets.getKeys();
+        }
+
+        @Override
+        public final List<String> listSecrets(final String roleName) throws VaultConnectorException {
+            requireAuth();
+
+            SecretListResponse secrets = request.get(
+                AUTH_APPROLE_ROLE + encode(roleName) + "/secret-id?list=true",
+                emptyMap(),
+                token,
+                SecretListResponse.class
+            );
+
+            return secrets.getKeys();
+        }
+    }
+
+    /**
+     * Sub-client for transit methods.
+     */
+    public class TransitClientImpl implements TransitClient {
+        @Override
+        public final TransitResponse encrypt(final String keyName, final String plaintext)
+            throws VaultConnectorException {
+            requireAuth();
+
+            Map<String, Object> payload = mapOf(
+                "plaintext", plaintext
+            );
+
+            return request.post(TRANSIT_ENCRYPT + encode(keyName), payload, token, TransitResponse.class);
+        }
+
+        @Override
+        public final TransitResponse decrypt(final String keyName, final String ciphertext)
+            throws VaultConnectorException {
+            requireAuth();
+
+            Map<String, Object> payload = mapOf(
+                "ciphertext", ciphertext
+            );
+
+            return request.post(TRANSIT_DECRYPT + encode(keyName), payload, token, TransitResponse.class);
+        }
+
+        @Override
+        public final TransitResponse hash(final String algorithm, final String input, final String format)
+            throws VaultConnectorException {
+            if (format != null && !"hex".equals(format) && !"base64".equals(format)) {
+                throw new IllegalArgumentException("Unsupported format " + format);
+            }
+
+            requireAuth();
+
+            Map<String, Object> payload = mapOf(
+                "input", input,
+                "format", format
+            );
+
+            return request.post(TRANSIT_HASH + encode(algorithm), payload, token, TransitResponse.class);
+        }
+    }
+
+    /**
+     * Sub-client for system methods.
+     */
+    public class SysClientImpl implements SysClient {
+
+        @Override
+        public final SealResponse sealStatus() throws VaultConnectorException {
+            return request.get(SYS_SEAL_STATUS, emptyMap(), token, SealResponse.class);
+        }
+
+        @Override
+        public final void seal() throws VaultConnectorException {
+            request.put(SYS_SEAL, emptyMap(), token);
+        }
+
+        @Override
+        public final SealResponse unseal(final String key, final Boolean reset) throws VaultConnectorException {
+            Map<String, String> param = mapOfStrings(
+                "key", key,
+                "reset", reset
+            );
+
+            return request.put(SYS_UNSEAL, param, token, SealResponse.class);
+        }
+
+        @Override
+        public HealthResponse getHealth() throws VaultConnectorException {
+
+            return request.get(
+                SYS_HEALTH,
+                // Force status code to be 200, so we don't need to modify the request sequence.
+                Map.of(
+                    "standbycode", "200",   // Default: 429.
+                    "sealedcode", "200",    // Default: 503.
+                    "uninitcode", "200"     // Default: 501.
+                ),
+                token,
+                HealthResponse.class
+            );
+        }
+
+        @Override
+        public final List<AuthBackend> getAuthBackends() throws VaultConnectorException {
+            /* Issue request and parse response */
+            AuthMethodsResponse amr = request.get(SYS_AUTH, emptyMap(), token, AuthMethodsResponse.class);
+
+            return amr.getSupportedMethods().values().stream().map(AuthMethod::getType).toList();
+        }
     }
 }

--- a/src/main/java/de/stklcode/jvault/connector/KV2Client.java
+++ b/src/main/java/de/stklcode/jvault/connector/KV2Client.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2016-2025 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector;
+
+import de.stklcode.jvault.connector.exception.VaultConnectorException;
+import de.stklcode.jvault.connector.model.response.MetadataResponse;
+import de.stklcode.jvault.connector.model.response.SecretResponse;
+import de.stklcode.jvault.connector.model.response.SecretVersionResponse;
+
+import java.util.Map;
+
+/**
+ * KV v2 client interface.
+ * Provides methods to interact with Vault's KV v2 API.
+ *
+ * @since 2.0.0 extracted from {@link VaultConnector}
+ */
+public interface KV2Client {
+
+    /**
+     * Retrieve the latest secret data for specific version from Vault.
+     * <br>
+     * Path {@code <mount>/data/<key>} is read here.
+     * Only available for KV v2 secrets.
+     *
+     * @param mount Secret store mount point (without leading or trailing slash).
+     * @param key   Secret identifier
+     * @return Secret response
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    default SecretResponse readData(final String mount, final String key) throws VaultConnectorException {
+        return readVersion(mount, key, null);
+    }
+
+    /**
+     * Write secret to Vault.
+     * <br>
+     * Path {@code <mount>/data/<key>} is written here.
+     * Only available for KV v2 secrets.
+     *
+     * @param mount Secret store mount point (without leading or trailing slash).
+     * @param key   Secret identifier
+     * @param data  Secret content. Value must be be JSON serializable.
+     * @return Metadata for the created/updated secret.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    default SecretVersionResponse writeData(final String mount,
+                                            final String key,
+                                            final Map<String, Object> data) throws VaultConnectorException {
+        return writeData(mount, key, data, null);
+    }
+
+    /**
+     * Write secret to Vault.
+     * <br>
+     * Path {@code <mount>/data/<key>} is written here.
+     * Only available for KV v2 secrets.
+     *
+     * @param mount Secret store mount point (without leading or trailing slash).
+     * @param key   Secret identifier
+     * @param data  Secret content. Value must be be JSON serializable.
+     * @param cas   Use Check-And-Set operation, i.e. only allow writing if current version matches this value.
+     * @return Metadata for the created/updated secret.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    SecretVersionResponse writeData(final String mount,
+                                    final String key,
+                                    final Map<String, Object> data,
+                                    final Integer cas) throws VaultConnectorException;
+
+    /**
+     * Retrieve secret data from Vault.
+     * <br>
+     * Path {@code <mount>/data/<key>} is read here.
+     * Only available for KV v2 secrets.
+     *
+     * @param mount   Secret store mount point (without leading or trailing slash).
+     * @param key     Secret identifier
+     * @param version Version to read. If {@code null} or zero, the latest version will be returned.
+     * @return Secret response.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    SecretResponse readVersion(final String mount, final String key, final Integer version)
+        throws VaultConnectorException;
+
+    /**
+     * Retrieve secret metadata from Vault.
+     * <br>
+     * Path {@code <mount>/metadata/<key>} is read here.
+     * Only available for KV v2 secrets.
+     *
+     * @param mount Secret store mount point (without leading or trailing slash).
+     * @param key   Secret identifier
+     * @return Metadata response
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    MetadataResponse readMetadata(final String mount, final String key) throws VaultConnectorException;
+
+    /**
+     * Update secret metadata.
+     * <br>
+     * Path {@code <mount>/metadata/<key>} is written here.
+     * Only available for KV v2 secrets.
+     *
+     * @param mount       Secret store mount point (without leading or trailing slash).
+     * @param key         Secret identifier
+     * @param maxVersions Maximum number of versions (fallback to backend default if {@code null})
+     * @param casRequired Specify if Check-And-Set is required for this secret.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    void updateMetadata(final String mount,
+                        final String key,
+                        final Integer maxVersions,
+                        final boolean casRequired) throws VaultConnectorException;
+
+    /**
+     * Delete latest version of a secret from Vault.
+     * <br>
+     * Only available for KV v2 stores.
+     *
+     * @param mount Secret store mount point (without leading or trailing slash).
+     * @param key   Secret path.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    void deleteLatestVersion(final String mount, final String key) throws VaultConnectorException;
+
+    /**
+     * Delete latest version of a secret from Vault.
+     * <br>
+     * Prefix {@code secret/} is automatically added to path.
+     * Only available for KV v2 stores.
+     *
+     * @param mount Secret store mount point (without leading or trailing slash).
+     * @param key   Secret path.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    void deleteAllVersions(final String mount, final String key) throws VaultConnectorException;
+
+    /**
+     * Delete secret versions from Vault.
+     * <br>
+     * Only available for KV v2 stores.
+     *
+     * @param mount    Secret store mount point (without leading or trailing slash).
+     * @param key      Secret path.
+     * @param versions Versions of the secret to delete.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    void deleteVersions(final String mount, final String key, final int... versions)
+        throws VaultConnectorException;
+
+    /**
+     * Undelete (restore) secret versions from Vault.
+     * Only available for KV v2 stores.
+     *
+     * @param mount    Secret store mount point (without leading or trailing slash).
+     * @param key      Secret path.
+     * @param versions Versions of the secret to undelete.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    void undeleteVersions(final String mount, final String key, final int... versions)
+        throws VaultConnectorException;
+
+    /**
+     * Destroy secret versions from Vault.
+     * Only available for KV v2 stores.
+     *
+     * @param mount    Secret store mount point (without leading or trailing slash).
+     * @param key      Secret path.
+     * @param versions Versions of the secret to destroy.
+     * @throws VaultConnectorException on error
+     * @since 0.8
+     */
+    void destroyVersions(final String mount, final String key, final int... versions)
+        throws VaultConnectorException;
+}

--- a/src/main/java/de/stklcode/jvault/connector/SysClient.java
+++ b/src/main/java/de/stklcode/jvault/connector/SysClient.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016-2025 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector;
+
+import de.stklcode.jvault.connector.exception.VaultConnectorException;
+import de.stklcode.jvault.connector.model.AuthBackend;
+import de.stklcode.jvault.connector.model.response.*;
+
+import java.util.List;
+
+/**
+ * Sys client interface.
+ * Provides methods to interact with Vault's system API.
+ *
+ * @since 2.0.0 extracted from {@link VaultConnector}
+ */
+public interface SysClient {
+
+    /**
+     * Retrieve status of vault seal.
+     *
+     * @return Seal status
+     * @throws VaultConnectorException on error
+     */
+    SealResponse sealStatus() throws VaultConnectorException;
+
+    /**
+     * Seal vault.
+     *
+     * @throws VaultConnectorException on error
+     */
+    void seal() throws VaultConnectorException;
+
+    /**
+     * Unseal vault.
+     *
+     * @param key   A single master share key
+     * @param reset Discard previously provided keys (optional)
+     * @return Response with seal status
+     * @throws VaultConnectorException on error
+     */
+    SealResponse unseal(final String key, final Boolean reset) throws VaultConnectorException;
+
+    /**
+     * Unseal vault.
+     *
+     * @param key A single master share key
+     * @return Response with seal status
+     * @throws VaultConnectorException on error
+     */
+    default SealResponse unseal(final String key) throws VaultConnectorException {
+        return unseal(key, null);
+    }
+
+    /**
+     * Query server health information.
+     *
+     * @return Health information.
+     * @throws VaultConnectorException on error
+     * @since 0.7.0
+     */
+    HealthResponse getHealth() throws VaultConnectorException;
+
+    /**
+     * Get all available authentication backends.
+     *
+     * @return List of backends
+     * @throws VaultConnectorException on error
+     */
+    List<AuthBackend> getAuthBackends() throws VaultConnectorException;
+
+}

--- a/src/main/java/de/stklcode/jvault/connector/TokenClient.java
+++ b/src/main/java/de/stklcode/jvault/connector/TokenClient.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016-2025 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector;
+
+import de.stklcode.jvault.connector.exception.VaultConnectorException;
+import de.stklcode.jvault.connector.model.Token;
+import de.stklcode.jvault.connector.model.TokenRole;
+import de.stklcode.jvault.connector.model.response.AuthResponse;
+import de.stklcode.jvault.connector.model.response.TokenResponse;
+import de.stklcode.jvault.connector.model.response.TokenRoleResponse;
+
+import java.util.List;
+
+/**
+ * Token client interface.
+ * Provides methods to interact with Vault's token API.
+ *
+ * @since 2.0.0 extracted from {@link VaultConnector}
+ */
+public interface TokenClient {
+
+    /**
+     * Create a new token.
+     *
+     * @param token the token
+     * @return the result response
+     * @throws VaultConnectorException on error
+     */
+    AuthResponse create(final Token token) throws VaultConnectorException;
+
+    /**
+     * Create a new token.
+     *
+     * @param token  the token
+     * @param orphan create orphan token
+     * @return the result response
+     * @throws VaultConnectorException on error
+     */
+    AuthResponse create(final Token token, boolean orphan) throws VaultConnectorException;
+
+    /**
+     * Create a new token for specific role.
+     *
+     * @param token the token
+     * @param role  the role name
+     * @return the result response
+     * @throws VaultConnectorException on error
+     */
+    AuthResponse create(final Token token, final String role) throws VaultConnectorException;
+
+    /**
+     * Lookup token information.
+     *
+     * @param token the token
+     * @return the result response
+     * @throws VaultConnectorException on error
+     */
+    TokenResponse lookup(final String token) throws VaultConnectorException;
+
+    /**
+     * Create a new or update an existing token role.
+     *
+     * @param role the role entity (name must be set)
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    default boolean createOrUpdateRole(final TokenRole role) throws VaultConnectorException {
+        return createOrUpdateRole(role.getName(), role);
+    }
+
+    /**
+     * Create a new or update an existing token role.
+     *
+     * @param name the role name (overrides name possibly set in role entity)
+     * @param role the role entity
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    boolean createOrUpdateRole(final String name, final TokenRole role) throws VaultConnectorException;
+
+    /**
+     * Lookup token information.
+     *
+     * @param name the role name
+     * @return the result response
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    TokenRoleResponse readRole(final String name) throws VaultConnectorException;
+
+    /**
+     * List available token roles from Vault.
+     *
+     * @return List of token roles
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    List<String> listRoles() throws VaultConnectorException;
+
+    /**
+     * Delete a token role.
+     *
+     * @param name the role name to delete
+     * @return {@code true} on success
+     * @throws VaultConnectorException on error
+     * @since 0.9
+     */
+    boolean deleteRole(final String name) throws VaultConnectorException;
+}

--- a/src/main/java/de/stklcode/jvault/connector/TransitClient.java
+++ b/src/main/java/de/stklcode/jvault/connector/TransitClient.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016-2025 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.jvault.connector;
+
+import de.stklcode.jvault.connector.exception.VaultConnectorException;
+import de.stklcode.jvault.connector.model.response.TransitResponse;
+
+import java.util.Base64;
+
+/**
+ * Transit client interface.
+ * Provides methods to interact with Vault's transit API.
+ *
+ * @since 2.0.0 extracted from {@link VaultConnector}
+ */
+public interface TransitClient {
+
+    /**
+     * Encrypt plaintext via transit engine from Vault.
+     *
+     * @param keyName   Transit key name
+     * @param plaintext Text to encrypt (Base64 encoded)
+     * @return Transit response
+     * @throws VaultConnectorException on error
+     * @since 1.5.0
+     */
+    TransitResponse encrypt(final String keyName, final String plaintext) throws VaultConnectorException;
+
+    /**
+     * Encrypt plaintext via transit engine from Vault.
+     *
+     * @param keyName   Transit key name
+     * @param plaintext Binary data to encrypt
+     * @return Transit response
+     * @throws VaultConnectorException on error
+     * @since 1.5.0
+     */
+    default TransitResponse encrypt(final String keyName, final byte[] plaintext)
+        throws VaultConnectorException {
+        return encrypt(keyName, Base64.getEncoder().encodeToString(plaintext));
+    }
+
+    /**
+     * Decrypt ciphertext via transit engine from Vault.
+     *
+     * @param keyName    Transit key name
+     * @param ciphertext Text to decrypt
+     * @return Transit response
+     * @throws VaultConnectorException on error
+     * @since 1.5.0
+     */
+    TransitResponse decrypt(final String keyName, final String ciphertext) throws VaultConnectorException;
+
+    /**
+     * Hash data in hex format via transit engine from Vault.
+     *
+     * @param algorithm Specifies the hash algorithm to use
+     * @param input     Data to hash
+     * @return Transit response
+     * @throws VaultConnectorException on error
+     * @since 1.5.0
+     */
+    default TransitResponse hash(final String algorithm, final String input) throws VaultConnectorException {
+        return hash(algorithm, input, "hex");
+    }
+
+    /**
+     * Hash data via transit engine from Vault.
+     *
+     * @param algorithm Specifies the hash algorithm to use
+     * @param input     Data to hash (Base64 encoded)
+     * @param format    Specifies the output encoding (hex/base64)
+     * @return Transit response
+     * @throws VaultConnectorException on error
+     * @since 1.5.0
+     */
+    TransitResponse hash(final String algorithm, final String input, final String format)
+        throws VaultConnectorException;
+
+    /**
+     * Hash data via transit engine from Vault.
+     *
+     * @param algorithm Specifies the hash algorithm to use
+     * @param input     Data to hash
+     * @return Transit response
+     * @throws VaultConnectorException on error
+     * @since 1.5.0
+     */
+    default TransitResponse hash(final String algorithm, final byte[] input, final String format)
+        throws VaultConnectorException {
+        return hash(algorithm, Base64.getEncoder().encodeToString(input), format);
+    }
+}

--- a/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
+++ b/src/main/java/de/stklcode/jvault/connector/VaultConnector.java
@@ -17,7 +17,6 @@
 package de.stklcode.jvault.connector;
 
 import de.stklcode.jvault.connector.exception.VaultConnectorException;
-import de.stklcode.jvault.connector.model.*;
 import de.stklcode.jvault.connector.model.response.*;
 
 import java.io.Serializable;
@@ -36,59 +35,6 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * Reset authorization information.
      */
     void resetAuth();
-
-    /**
-     * Retrieve status of vault seal.
-     *
-     * @return Seal status
-     * @throws VaultConnectorException on error
-     */
-    SealResponse sealStatus() throws VaultConnectorException;
-
-    /**
-     * Seal vault.
-     *
-     * @throws VaultConnectorException on error
-     */
-    void seal() throws VaultConnectorException;
-
-    /**
-     * Unseal vault.
-     *
-     * @param key   A single master share key
-     * @param reset Discard previously provided keys (optional)
-     * @return Response with seal status
-     * @throws VaultConnectorException on error
-     */
-    SealResponse unseal(final String key, final Boolean reset) throws VaultConnectorException;
-
-    /**
-     * Unseal vault.
-     *
-     * @param key A single master share key
-     * @return Response with seal status
-     * @throws VaultConnectorException on error
-     */
-    default SealResponse unseal(final String key) throws VaultConnectorException {
-        return unseal(key, null);
-    }
-
-    /**
-     * Query server health information.
-     *
-     * @return Health information.
-     * @throws VaultConnectorException on error
-     * @since 0.7.0
-     */
-    HealthResponse getHealth() throws VaultConnectorException;
-
-    /**
-     * Get all available authentication backends.
-     *
-     * @return List of backends
-     * @throws VaultConnectorException on error
-     */
-    List<AuthBackend> getAuthBackends() throws VaultConnectorException;
 
     /**
      * Authorize to Vault using token.
@@ -133,187 +79,6 @@ public interface VaultConnector extends AutoCloseable, Serializable {
     AuthResponse authAppRole(final String roleID, final String secretID) throws VaultConnectorException;
 
     /**
-     * Register a new AppRole role from given metamodel.
-     *
-     * @param role The role
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    boolean createAppRole(final AppRole role) throws VaultConnectorException;
-
-    /**
-     * Register new AppRole role with default policy.
-     *
-     * @param roleName The role name
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    default boolean createAppRole(final String roleName) throws VaultConnectorException {
-        return createAppRole(roleName, new ArrayList<>());
-    }
-
-    /**
-     * Register new AppRole role with policies.
-     *
-     * @param roleName The role name
-     * @param policies The policies to associate with
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    default boolean createAppRole(final String roleName, final List<String> policies) throws VaultConnectorException {
-        return createAppRole(roleName, policies, null);
-    }
-
-    /**
-     * Register new AppRole role with default policy and custom ID.
-     *
-     * @param roleName The role name
-     * @param roleID   A custom role ID
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    default boolean createAppRole(final String roleName, final String roleID) throws VaultConnectorException {
-        return createAppRole(roleName, new ArrayList<>(), roleID);
-    }
-
-    /**
-     * Register new AppRole role with policies and custom ID.
-     *
-     * @param roleName The role name
-     * @param policies The policies to associate with
-     * @param roleID   A custom role ID
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    default boolean createAppRole(final String roleName, final List<String> policies, final String roleID)
-        throws VaultConnectorException {
-        return createAppRole(AppRole.builder(roleName).withTokenPolicies(policies).withId(roleID).build());
-    }
-
-    /**
-     * Delete AppRole role from Vault.
-     *
-     * @param roleName The role name
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     */
-    boolean deleteAppRole(final String roleName) throws VaultConnectorException;
-
-    /**
-     * Lookup an AppRole role.
-     *
-     * @param roleName The role name
-     * @return Result of the lookup
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    AppRoleResponse lookupAppRole(final String roleName) throws VaultConnectorException;
-
-    /**
-     * Retrieve ID for an AppRole role.
-     *
-     * @param roleName The role name
-     * @return The role ID
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    String getAppRoleID(final String roleName) throws VaultConnectorException;
-
-    /**
-     * Set custom ID for an AppRole role.
-     *
-     * @param roleName The role name
-     * @param roleID   The role ID
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    boolean setAppRoleID(final String roleName, final String roleID) throws VaultConnectorException;
-
-    /**
-     * Register new random generated AppRole secret.
-     *
-     * @param roleName The role name
-     * @return The secret ID
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    default AppRoleSecretResponse createAppRoleSecret(final String roleName) throws VaultConnectorException {
-        return createAppRoleSecret(roleName, new AppRoleSecret());
-    }
-
-    /**
-     * Register new AppRole secret with custom ID.
-     *
-     * @param roleName The role name
-     * @param secretID A custom secret ID
-     * @return The secret ID
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    default AppRoleSecretResponse createAppRoleSecret(final String roleName, final String secretID)
-        throws VaultConnectorException {
-        return createAppRoleSecret(roleName, new AppRoleSecret(secretID));
-    }
-
-    /**
-     * Register new AppRole secret with custom ID.
-     *
-     * @param roleName The role name
-     * @param secret   The secret meta object
-     * @return The secret ID
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    AppRoleSecretResponse createAppRoleSecret(final String roleName, final AppRoleSecret secret)
-        throws VaultConnectorException;
-
-    /**
-     * Lookup an AppRole secret.
-     *
-     * @param roleName The role name
-     * @param secretID The secret ID
-     * @return Result of the lookup
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    AppRoleSecretResponse lookupAppRoleSecret(final String roleName, final String secretID)
-        throws VaultConnectorException;
-
-    /**
-     * Destroy an AppRole secret.
-     *
-     * @param roleName The role name
-     * @param secretID The secret meta object
-     * @return The secret ID
-     * @throws VaultConnectorException on error
-     * @since 0.4.0
-     */
-    boolean destroyAppRoleSecret(final String roleName, final String secretID) throws VaultConnectorException;
-
-    /**
-     * List existing (accessible) AppRole roles.
-     *
-     * @return List of roles
-     * @throws VaultConnectorException on error
-     */
-    List<String> listAppRoles() throws VaultConnectorException;
-
-    /**
-     * List existing (accessible) secret IDs for AppRole role.
-     *
-     * @param roleName The role name
-     * @return List of roles
-     * @throws VaultConnectorException on error
-     */
-    List<String> listAppRoleSecrets(final String roleName) throws VaultConnectorException;
-
-    /**
      * Get authorization status.
      *
      * @return TRUE, if successfully authorized
@@ -329,108 +94,6 @@ public interface VaultConnector extends AutoCloseable, Serializable {
      * @since 0.5.0
      */
     SecretResponse read(final String key) throws VaultConnectorException;
-
-    /**
-     * Retrieve the latest secret data for specific version from Vault.
-     * <br>
-     * Path {@code <mount>/data/<key>} is read here.
-     * Only available for KV v2 secrets.
-     *
-     * @param mount Secret store mount point (without leading or trailing slash).
-     * @param key   Secret identifier
-     * @return Secret response
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    default SecretResponse readSecretData(final String mount, final String key) throws VaultConnectorException {
-        return readSecretVersion(mount, key, null);
-    }
-
-    /**
-     * Write secret to Vault.
-     * <br>
-     * Path {@code <mount>/data/<key>} is written here.
-     * Only available for KV v2 secrets.
-     *
-     * @param mount Secret store mount point (without leading or trailing slash).
-     * @param key   Secret identifier
-     * @param data  Secret content. Value must be be JSON serializable.
-     * @return Metadata for the created/updated secret.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    default SecretVersionResponse writeSecretData(final String mount,
-                                                  final String key,
-                                                  final Map<String, Object> data) throws VaultConnectorException {
-        return writeSecretData(mount, key, data, null);
-    }
-
-    /**
-     * Write secret to Vault.
-     * <br>
-     * Path {@code <mount>/data/<key>} is written here.
-     * Only available for KV v2 secrets.
-     *
-     * @param mount Secret store mount point (without leading or trailing slash).
-     * @param key   Secret identifier
-     * @param data  Secret content. Value must be be JSON serializable.
-     * @param cas   Use Check-And-Set operation, i.e. only allow writing if current version matches this value.
-     * @return Metadata for the created/updated secret.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    SecretVersionResponse writeSecretData(final String mount,
-                                          final String key,
-                                          final Map<String, Object> data,
-                                          final Integer cas) throws VaultConnectorException;
-
-    /**
-     * Retrieve secret data from Vault.
-     * <br>
-     * Path {@code <mount>/data/<key>} is read here.
-     * Only available for KV v2 secrets.
-     *
-     * @param mount   Secret store mount point (without leading or trailing slash).
-     * @param key     Secret identifier
-     * @param version Version to read. If {@code null} or zero, the latest version will be returned.
-     * @return Secret response.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    SecretResponse readSecretVersion(final String mount, final String key, final Integer version)
-        throws VaultConnectorException;
-
-    /**
-     * Retrieve secret metadata from Vault.
-     * <br>
-     * Path {@code <mount>/metadata/<key>} is read here.
-     * Only available for KV v2 secrets.
-     *
-     * @param mount Secret store mount point (without leading or trailing slash).
-     * @param key   Secret identifier
-     * @return Metadata response
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    MetadataResponse readSecretMetadata(final String mount, final String key) throws VaultConnectorException;
-
-    /**
-     * Update secret metadata.
-     * <br>
-     * Path {@code <mount>/metadata/<key>} is written here.
-     * Only available for KV v2 secrets.
-     *
-     * @param mount       Secret store mount point (without leading or trailing slash).
-     * @param key         Secret identifier
-     * @param maxVersions Maximum number of versions (fallback to backend default if {@code null})
-     * @param casRequired Specify if Check-And-Set is required for this secret.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    void updateSecretMetadata(final String mount,
-                              final String key,
-                              final Integer maxVersions,
-                              final boolean casRequired) throws VaultConnectorException;
 
     /**
      * List available nodes from Vault.
@@ -488,71 +151,6 @@ public interface VaultConnector extends AutoCloseable, Serializable {
     void delete(final String key) throws VaultConnectorException;
 
     /**
-     * Delete latest version of a secret from Vault.
-     * <br>
-     * Only available for KV v2 stores.
-     *
-     * @param mount Secret store mount point (without leading or trailing slash).
-     * @param key   Secret path.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    void deleteLatestSecretVersion(final String mount, final String key) throws VaultConnectorException;
-
-    /**
-     * Delete latest version of a secret from Vault.
-     * <br>
-     * Prefix {@code secret/} is automatically added to path.
-     * Only available for KV v2 stores.
-     *
-     * @param mount Secret store mount point (without leading or trailing slash).
-     * @param key   Secret path.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    void deleteAllSecretVersions(final String mount, final String key) throws VaultConnectorException;
-
-    /**
-     * Delete secret versions from Vault.
-     * <br>
-     * Only available for KV v2 stores.
-     *
-     * @param mount    Secret store mount point (without leading or trailing slash).
-     * @param key      Secret path.
-     * @param versions Versions of the secret to delete.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    void deleteSecretVersions(final String mount, final String key, final int... versions)
-        throws VaultConnectorException;
-
-    /**
-     * Undelete (restore) secret versions from Vault.
-     * Only available for KV v2 stores.
-     *
-     * @param mount    Secret store mount point (without leading or trailing slash).
-     * @param key      Secret path.
-     * @param versions Versions of the secret to undelete.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    void undeleteSecretVersions(final String mount, final String key, final int... versions)
-        throws VaultConnectorException;
-
-    /**
-     * Destroy secret versions from Vault.
-     * Only available for KV v2 stores.
-     *
-     * @param mount    Secret store mount point (without leading or trailing slash).
-     * @param key      Secret path.
-     * @param versions Versions of the secret to destroy.
-     * @throws VaultConnectorException on error
-     * @since 0.8
-     */
-    void destroySecretVersions(final String mount, final String key, final int... versions)
-        throws VaultConnectorException;
-
-    /**
      * Revoke given lease immediately.
      *
      * @param leaseID the lease ID
@@ -582,170 +180,44 @@ public interface VaultConnector extends AutoCloseable, Serializable {
     SecretResponse renew(final String leaseID, final Integer increment) throws VaultConnectorException;
 
     /**
-     * Create a new token.
+     * Get client for KV v2 API.
      *
-     * @param token the token
-     * @return the result response
-     * @throws VaultConnectorException on error
+     * @return KV v2 client
+     * @since 2.0.0
      */
-    AuthResponse createToken(final Token token) throws VaultConnectorException;
+    KV2Client kv2();
 
     /**
-     * Create a new token.
+     * Get client for token API.
      *
-     * @param token  the token
-     * @param orphan create orphan token
-     * @return the result response
-     * @throws VaultConnectorException on error
+     * @return Token client
+     * @since 2.0.0
      */
-    AuthResponse createToken(final Token token, boolean orphan) throws VaultConnectorException;
+    TokenClient token();
 
     /**
-     * Create a new token for specific role.
+     * Get client for AppRole API.
      *
-     * @param token the token
-     * @param role  the role name
-     * @return the result response
-     * @throws VaultConnectorException on error
+     * @return AppRole client
+     * @since 2.0.0
      */
-    AuthResponse createToken(final Token token, final String role) throws VaultConnectorException;
+    AppRoleClient appRole();
 
     /**
-     * Lookup token information.
+     * Get client for transit API.
      *
-     * @param token the token
-     * @return the result response
-     * @throws VaultConnectorException on error
+     * @return Transit client
+     * @since 2.0.0
      */
-    TokenResponse lookupToken(final String token) throws VaultConnectorException;
+    TransitClient transit();
 
     /**
-     * Create a new or update an existing token role.
+     * Get client for system API.
      *
-     * @param role the role entity (name must be set)
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.9
+     * @return System client
+     * @since 2.0.0
      */
-    default boolean createOrUpdateTokenRole(final TokenRole role) throws VaultConnectorException {
-        return createOrUpdateTokenRole(role.getName(), role);
-    }
-
-    /**
-     * Create a new or update an existing token role.
-     *
-     * @param name the role name (overrides name possibly set in role entity)
-     * @param role the role entity
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.9
-     */
-    boolean createOrUpdateTokenRole(final String name, final TokenRole role) throws VaultConnectorException;
-
-    /**
-     * Lookup token information.
-     *
-     * @param name the role name
-     * @return the result response
-     * @throws VaultConnectorException on error
-     * @since 0.9
-     */
-    TokenRoleResponse readTokenRole(final String name) throws VaultConnectorException;
-
-    /**
-     * List available token roles from Vault.
-     *
-     * @return List of token roles
-     * @throws VaultConnectorException on error
-     * @since 0.9
-     */
-    List<String> listTokenRoles() throws VaultConnectorException;
-
-    /**
-     * Delete a token role.
-     *
-     * @param name the role name to delete
-     * @return {@code true} on success
-     * @throws VaultConnectorException on error
-     * @since 0.9
-     */
-    boolean deleteTokenRole(final String name) throws VaultConnectorException;
-
-    /**
-     * Encrypt plaintext via transit engine from Vault.
-     *
-     * @param keyName   Transit key name
-     * @param plaintext Text to encrypt (Base64 encoded)
-     * @return Transit response
-     * @throws VaultConnectorException on error
-     * @since 1.5.0
-     */
-    TransitResponse transitEncrypt(final String keyName, final String plaintext) throws VaultConnectorException;
-
-    /**
-     * Encrypt plaintext via transit engine from Vault.
-     *
-     * @param keyName   Transit key name
-     * @param plaintext Binary data to encrypt
-     * @return Transit response
-     * @throws VaultConnectorException on error
-     * @since 1.5.0
-     */
-    default TransitResponse transitEncrypt(final String keyName, final byte[] plaintext)
-        throws VaultConnectorException {
-        return transitEncrypt(keyName, Base64.getEncoder().encodeToString(plaintext));
-    }
-
-    /**
-     * Decrypt ciphertext via transit engine from Vault.
-     *
-     * @param keyName    Transit key name
-     * @param ciphertext Text to decrypt
-     * @return Transit response
-     * @throws VaultConnectorException on error
-     * @since 1.5.0
-     */
-    TransitResponse transitDecrypt(final String keyName, final String ciphertext) throws VaultConnectorException;
-
-    /**
-     * Hash data in hex format via transit engine from Vault.
-     *
-     * @param algorithm Specifies the hash algorithm to use
-     * @param input     Data to hash
-     * @return Transit response
-     * @throws VaultConnectorException on error
-     * @since 1.5.0
-     */
-    default TransitResponse transitHash(final String algorithm, final String input) throws VaultConnectorException {
-        return transitHash(algorithm, input, "hex");
-    }
-
-    /**
-     * Hash data via transit engine from Vault.
-     *
-     * @param algorithm Specifies the hash algorithm to use
-     * @param input     Data to hash (Base64 encoded)
-     * @param format    Specifies the output encoding (hex/base64)
-     * @return Transit response
-     * @throws VaultConnectorException on error
-     * @since 1.5.0
-     */
-    TransitResponse transitHash(final String algorithm, final String input, final String format)
-        throws VaultConnectorException;
-
-    /**
-     * Hash data via transit engine from Vault.
-     *
-     * @param algorithm Specifies the hash algorithm to use
-     * @param input     Data to hash
-     * @return Transit response
-     * @throws VaultConnectorException on error
-     * @since 1.5.0
-     */
-    default TransitResponse transitHash(final String algorithm, final byte[] input, final String format)
-        throws VaultConnectorException {
-        return transitHash(algorithm, Base64.getEncoder().encodeToString(input), format);
-    }
+    SysClient sys();
 
     /**
      * Read credentials for database backends.
@@ -760,4 +232,5 @@ public interface VaultConnector extends AutoCloseable, Serializable {
         throws VaultConnectorException {
         return (CredentialsResponse) read(mount + "/creds/" + role);
     }
+
 }


### PR DESCRIPTION
The connector interface has grown quite big and does not even cover all potential APIs. We now extract functionality into submodules and group them to handle each area in separate interfaces. Provide fluent access, strip prefixes from methods and preserve a 1:1 migration path.

**Examples:**

| before                          | after                           |
|---------------------------------|---------------------------------|
| `connector.seal()`              | `connector.sys().seal()`        |
| `connector.unseal()`            | `connector.sys().unseal()`      |
| `connector.readSecretVersion()` | `connector.kv2().readVersion()` |
| `connector.createToken()`       | `connector.token().create()`    |
| `connector.lookupAppRole()`     | `connector.appRole().lookup()`  |
| `connector.transitHash()`       | `connector.transit().hash()`    |