### PR TITLE
test: update junit-jupiter to v6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.13.4</version>
+            <version>6.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
We do not used any APIs marked as deprecated in v5 and we require Java 17, so this update should be a drop-in replacement.